### PR TITLE
chore: move dark mode and github under profile dropdown

### DIFF
--- a/frontend/src/app/[locale]/DropdownAccount.tsx
+++ b/frontend/src/app/[locale]/DropdownAccount.tsx
@@ -2,11 +2,12 @@
 import { Button, DropdownTrigger, Dropdown, DropdownMenu, DropdownItem } from '@heroui/react';
 import { ChevronDown, PenTool, ArrowRightFromLine, ArrowRightToLine, Settings } from 'lucide-react';
 import { useContext } from 'react';
+import { useTheme } from 'next-themes';
 import { TokenContext } from '@/utils/TokenProvider';
 import { useRouter } from '@/src/i18n/routing';
 import { AccountDropDownMessages } from '@/types/user';
 import UserAvatar from '@/components/UserAvatar';
-import { GithubIcon } from '@/components/icons';
+import { GithubIcon, SunFilledIcon, MoonFilledIcon } from '@/components/icons';
 
 type Props = {
   messages: AccountDropDownMessages;
@@ -17,6 +18,7 @@ type Props = {
 export default function DropdownAccount({ messages, locale, onItemPress }: Props) {
   const router = useRouter();
   const context = useContext(TokenContext);
+  const { theme, setTheme } = useTheme();
 
   const signOut = () => {
     context.setToken({
@@ -26,6 +28,10 @@ export default function DropdownAccount({ messages, locale, onItemPress }: Props
     });
     context.removeTokenFromLocalStorage();
     router.push(`/account/signin`, { locale: locale });
+  };
+
+  const toggleTheme = () => {
+    setTheme(theme === 'light' ? 'dark' : 'light');
   };
 
   const signinItems = [
@@ -55,6 +61,15 @@ export default function DropdownAccount({ messages, locale, onItemPress }: Props
       icon: <GithubIcon size={16} />,
       onPress: () => {
         window.open('https://github.com/kimatata/unittcms', '_blank');
+        onItemPress();
+      },
+    },
+    {
+      uid: 'theme',
+      title: theme === 'light' ? 'Dark Mode' : 'Light Mode',
+      icon: theme === 'light' ? <MoonFilledIcon size={16} /> : <SunFilledIcon size={16} />,
+      onPress: () => {
+        toggleTheme();
         onItemPress();
       },
     },
@@ -94,6 +109,15 @@ export default function DropdownAccount({ messages, locale, onItemPress }: Props
       icon: <GithubIcon size={16} />,
       onPress: () => {
         window.open('https://github.com/kimatata/unittcms', '_blank');
+        onItemPress();
+      },
+    },
+    {
+      uid: 'theme',
+      title: theme === 'light' ? 'Dark Mode' : 'Light Mode',
+      icon: theme === 'light' ? <MoonFilledIcon size={16} /> : <SunFilledIcon size={16} />,
+      onPress: () => {
+        toggleTheme();
         onItemPress();
       },
     },

--- a/frontend/src/app/[locale]/HeaderNavbarMenu.tsx
+++ b/frontend/src/app/[locale]/HeaderNavbarMenu.tsx
@@ -16,7 +16,6 @@ import {
 import { ArrowRightFromLine, ArrowRightToLine, File, Globe, MoveUpRight, PenTool, Settings } from 'lucide-react';
 import DropdownAccount from './DropdownAccount';
 import DropdownLanguage from './DropdownLanguage';
-import { ThemeSwitch } from '@/components/ThemeSwitch';
 import { locales } from '@/config/selection';
 import { Link, useRouter } from '@/src/i18n/routing';
 import { TokenContext } from '@/utils/TokenProvider';
@@ -129,7 +128,6 @@ export default function HeaderNavbarMenu({ messages, locale }: Props) {
       </NavbarContent>
 
       <NavbarContent className="basis-1 pl-4" justify="end">
-        <ThemeSwitch />
         <div className="hidden md:block">
           <DropdownAccount messages={messages} locale={locale} onItemPress={() => {}} />
           <DropdownLanguage locale={locale} onChangeLocale={changeLocale} />


### PR DESCRIPTION
## Description

Addresses #354 

Consolidates UI controls by moving the GitHub link and dark mode toggle from the main navbar into the user profile dropdown menu.

https://github.com/user-attachments/assets/3000fc76-8256-4cfc-a2b3-3233c2e0ed26

