### PR TITLE
fix: Step case overwriting prevention by hypothetical ID

### DIFF
--- a/frontend/src/app/[locale]/projects/[projectId]/folders/[folderId]/cases/[caseId]/CaseEditor.tsx
+++ b/frontend/src/app/[locale]/projects/[projectId]/folders/[folderId]/cases/[caseId]/CaseEditor.tsx
@@ -209,12 +209,15 @@ export default function CaseEditor({
       return;
     }
 
-    const stepIndex = testCase.Steps.findIndex((step) => step.id === stepId);
-    testCase.Steps[stepIndex] = changeStep;
-
     setTestCase({
       ...testCase,
-      Steps: testCase.Steps,
+      Steps: testCase.Steps.map((step) => {
+        if (step.id === stepId) {
+          return changeStep;
+        } else {
+          return step;
+        }
+      }),
     });
   };
 

--- a/frontend/src/app/[locale]/projects/[projectId]/folders/[folderId]/cases/[caseId]/CaseEditor.tsx
+++ b/frontend/src/app/[locale]/projects/[projectId]/folders/[folderId]/cases/[caseId]/CaseEditor.tsx
@@ -60,7 +60,7 @@ export default function CaseEditor({
   const [testCase, setTestCase] = useState<CaseType>(defaultTestCase);
   const [isTitleInvalid] = useState<boolean>(false);
   const [isUpdating, setIsUpdating] = useState<boolean>(false);
-  const [plusCount, setPlusCount] = useState<number>(0);
+  const [idCounter, setIdCounter] = useState<number>(0);
   const [isDirty, setIsDirty] = useState(false);
   const [selectedTags, setSelectedTags] = useState<{ id: number; name: string }[]>([]);
 
@@ -68,9 +68,14 @@ export default function CaseEditor({
   useFormGuard(isDirty, messages.areYouSureLeave);
 
   const onPlusClick = async (newStepNo: number) => {
+    if (!testCase.Steps) {
+      return;
+    }
     setIsDirty(true);
+    const nextId = idCounter + 1;
     const newStep: StepType = {
-      id: plusCount,
+      // hypothetical ID
+      id: nextId,
       step: '',
       result: '',
       createdAt: new Date(),
@@ -78,66 +83,65 @@ export default function CaseEditor({
       caseSteps: {
         stepNo: newStepNo,
       },
-      uid: `uid${plusCount}`,
+      uid: `uid${nextId}`,
       editState: 'new',
     };
-    setPlusCount(plusCount + 1);
 
-    if (testCase.Steps) {
-      const updatedSteps = testCase.Steps.map((step) => {
-        if (step.caseSteps.stepNo >= newStepNo) {
-          return {
-            ...step,
-            editState: step.editState === 'notChanged' ? 'changed' : step.editState,
-            caseSteps: {
-              ...step.caseSteps,
-              stepNo: step.caseSteps.stepNo + 1,
-            },
-          };
-        }
-        return step;
-      });
+    const updatedSteps = testCase.Steps.map((step) => {
+      if (step.caseSteps.stepNo >= newStepNo) {
+        return {
+          ...step,
+          editState: step.editState === 'notChanged' ? 'changed' : step.editState,
+          caseSteps: {
+            ...step.caseSteps,
+            stepNo: step.caseSteps.stepNo + 1,
+          },
+        };
+      }
+      return step;
+    });
 
-      updatedSteps.push(newStep);
+    updatedSteps.push(newStep);
 
-      setTestCase({
-        ...testCase,
-        Steps: updatedSteps,
-      });
-    }
+    setTestCase({
+      ...testCase,
+      Steps: updatedSteps,
+    });
+    setIdCounter(nextId);
   };
 
   const onDeleteClick = async (stepId: number) => {
     setIsDirty(true);
-
-    // find deletedStep's stepNo
-    if (testCase.Steps) {
-      const deletedStep = testCase.Steps.find((step) => step.id === stepId);
-      if (!deletedStep) {
-        return;
-      }
-      const deletedStepNo = deletedStep.caseSteps.stepNo;
-      deletedStep.editState = 'deleted';
-
-      const updatedSteps = testCase.Steps.map((step) => {
-        if (step.caseSteps.stepNo > deletedStepNo) {
-          return {
-            ...step,
-            editState: step.editState === 'notChanged' ? 'changed' : step.editState,
-            caseSteps: {
-              ...step.caseSteps,
-              stepNo: step.caseSteps.stepNo - 1,
-            },
-          };
-        }
-        return step;
-      });
-
-      setTestCase({
-        ...testCase,
-        Steps: updatedSteps,
-      });
+    if (!testCase.Steps) {
+      return;
     }
+    // find deletedStep's stepNo
+
+    const deletedStep = testCase.Steps.find((step) => step.id === stepId);
+    if (!deletedStep) {
+      return;
+    }
+    const deletedStepNo = deletedStep.caseSteps.stepNo;
+    deletedStep.editState = 'deleted';
+
+    const updatedSteps = testCase.Steps.map((step) => {
+      if (step.caseSteps.stepNo > deletedStepNo) {
+        return {
+          ...step,
+          editState: step.editState === 'notChanged' ? 'changed' : step.editState,
+          caseSteps: {
+            ...step.caseSteps,
+            stepNo: step.caseSteps.stepNo - 1,
+          },
+        };
+      }
+      return step;
+    });
+
+    setTestCase({
+      ...testCase,
+      Steps: updatedSteps,
+    });
   };
 
   const handleDrop = (event: DragEvent<HTMLElement>) => {
@@ -201,18 +205,17 @@ export default function CaseEditor({
       changeStep.editState = 'changed';
     }
 
-    if (testCase.Steps) {
-      setTestCase({
-        ...testCase,
-        Steps: testCase.Steps.map((step) => {
-          if (step.id === stepId) {
-            return changeStep;
-          } else {
-            return step;
-          }
-        }),
-      });
+    if (!testCase.Steps) {
+      return;
     }
+
+    const stepIndex = testCase.Steps.findIndex((step) => step.id === stepId);
+    testCase.Steps[stepIndex] = changeStep;
+
+    setTestCase({
+      ...testCase,
+      Steps: testCase.Steps,
+    });
   };
 
   useEffect(() => {
@@ -223,6 +226,11 @@ export default function CaseEditor({
         data.Steps.forEach((step: StepType) => {
           step.editState = 'notChanged';
         });
+
+        // set idCounter to the max step id to avoid id conflict for new steps
+        // id is not reflected on database
+        const maxStepId = data.Steps.reduce((maxId: number, step: StepType) => Math.max(maxId, step.id), 0);
+        setIdCounter(maxStepId);
         setTestCase(data);
         if (data.Tags) {
           setSelectedTags(Array.isArray(data.Tags) ? data.Tags : []);

--- a/frontend/src/app/[locale]/projects/[projectId]/folders/[folderId]/cases/[caseId]/CaseStepsEditor.tsx
+++ b/frontend/src/app/[locale]/projects/[projectId]/folders/[folderId]/cases/[caseId]/CaseStepsEditor.tsx
@@ -27,7 +27,7 @@ export default function StepsEditor({ isDisabled, steps, onStepUpdate, onStepPlu
       {filteredSteps.map((step, index) => (
         <div key={index} className="flex items-center my-1">
           <Avatar className="me-2" size="sm" name={step.caseSteps.stepNo.toString()} />
-          <div key={step.id} className="grow flex gap-2">
+          <div key={step.uid} className="grow flex gap-2">
             <div className="w-1/2">
               <Textarea
                 size="sm"

--- a/frontend/src/app/[locale]/projects/[projectId]/folders/[folderId]/cases/[caseId]/CaseStepsEditor.tsx
+++ b/frontend/src/app/[locale]/projects/[projectId]/folders/[folderId]/cases/[caseId]/CaseStepsEditor.tsx
@@ -27,7 +27,7 @@ export default function StepsEditor({ isDisabled, steps, onStepUpdate, onStepPlu
       {filteredSteps.map((step, index) => (
         <div key={index} className="flex items-center my-1">
           <Avatar className="me-2" size="sm" name={step.caseSteps.stepNo.toString()} />
-          <div key={step.uid} className="grow flex gap-2">
+          <div key={step.id} className="grow flex gap-2">
             <div className="w-1/2">
               <Textarea
                 size="sm"


### PR DESCRIPTION
Closes: https://github.com/kimatata/unittcms/issues/392

## Context
We have found a bug when having a step based test, step may overwrite each other

## Problem
The reason of overwriting and overlapping is because `plusCount` may have the same value with ID
since plusCount is always starts at 0, it may clash with value already stored in database (step with id 1)

## Description

1. Create an idCounter, to keep track of ID. 
2. on first load (useEffect), the idCounter will be set the Max value of id in the TestCase
3. on add step, it will increment

note:

I changed update and delete code as well, it is not required, please tell me if you want to revert.
I feel that is cleaner code


