### PR TITLE
Fix issue #407: Implements logic to avoid duplicate step numbers when two users edit at the same time without refresh the page

### DIFF
--- a/backend/routes/steps/edit.js
+++ b/backend/routes/steps/edit.js
@@ -36,18 +36,6 @@ export default function (sequelize) {
       return newStep;
     };
 
-    const deleteStep = async (step) => {
-      await CaseStep.destroy({
-        where: { stepId: step.id },
-        transaction: t,
-      });
-      await Step.destroy({
-        where: { id: step.id },
-        transaction: t,
-      });
-      return null;
-    };
-
     const updateStep = async (step) => {
       await Step.update(step, {
         where: { id: step.id },
@@ -64,13 +52,34 @@ export default function (sequelize) {
       );
       return step;
     };
+
+    const deleteCaseStep = async (caseStep) => {
+      await CaseStep.destroy({
+        where: { stepId: caseStep.stepId },
+        transaction: t,
+      });
+      await Step.destroy({
+        where: { id: caseStep.stepId },
+        transaction: t,
+      });
+      return null;
+    };
+
     try {
+      const existingCaseSteps = await CaseStep.findAll({ where: { caseId: caseId } }, { transaction: t });
+      const stepsIdsFromRequest = steps.filter((step) => step.id != null).map((step) => step.id);
+      const caseStepsToDelete = existingCaseSteps.filter(
+        (existingStep) => !stepsIdsFromRequest.includes(existingStep.stepId)
+      );
+
+      if (caseStepsToDelete.length > 0) {
+        await Promise.all(caseStepsToDelete.map((caseStep) => deleteCaseStep(caseStep)));
+      }
+
       const results = await Promise.all(
         steps.map(async (step) => {
           if (step.editState === 'new') {
             return createStep(step);
-          } else if (step.editState === 'deleted') {
-            return deleteStep(step);
           } else if (step.editState === 'changed') {
             return updateStep(step);
           } else if (step.editState === 'notChanged') {

--- a/backend/routes/steps/edit.js
+++ b/backend/routes/steps/edit.js
@@ -13,7 +13,7 @@ export default function (sequelize) {
   const { verifyProjectDeveloperFromCaseId } = editableMiddleware(sequelize);
 
   router.post('/update', verifySignedIn, verifyProjectDeveloperFromCaseId, async (req, res) => {
-    const caseId = req.query.caseId;
+    const caseId = Number(req.query.caseId);
     const steps = req.body;
     const t = await sequelize.transaction();
 
@@ -37,16 +37,22 @@ export default function (sequelize) {
     };
 
     const updateStep = async (step) => {
-      await Step.update(step, {
-        where: { id: step.id },
-        transaction: t,
-      });
+      await Step.update(
+        {
+          step: step.step,
+          result: step.result,
+        },
+        {
+          where: { id: step.id },
+          transaction: t,
+        }
+      );
       await CaseStep.update(
         {
           stepNo: step.caseSteps.stepNo,
         },
         {
-          where: { stepId: step.id },
+          where: { caseId, stepId: step.id },
           transaction: t,
         }
       );
@@ -55,7 +61,7 @@ export default function (sequelize) {
 
     const deleteCaseStep = async (caseStep) => {
       await CaseStep.destroy({
-        where: { stepId: caseStep.stepId },
+        where: { caseId, stepId: caseStep.stepId },
         transaction: t,
       });
       await Step.destroy({
@@ -66,7 +72,10 @@ export default function (sequelize) {
     };
 
     try {
-      const existingCaseSteps = await CaseStep.findAll({ where: { caseId: caseId } }, { transaction: t });
+      const existingCaseSteps = await CaseStep.findAll({
+        where: { caseId: caseId },
+        transaction: t,
+      });
       const stepsIdsFromRequest = steps.filter((step) => step.id != null).map((step) => step.id);
       const caseStepsToDelete = existingCaseSteps.filter(
         (existingStep) => !stepsIdsFromRequest.includes(existingStep.stepId)

--- a/backend/routes/steps/edit.test.js
+++ b/backend/routes/steps/edit.test.js
@@ -1,0 +1,198 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import request from 'supertest';
+import express from 'express';
+import { Sequelize } from 'sequelize';
+import stepEditRoute from './edit';
+
+vi.mock('../../middleware/auth.js', () => ({
+  default: () => ({
+    verifySignedIn: vi.fn((req, res, next) => {
+      req.userId = 1;
+      next();
+    }),
+  }),
+}));
+
+vi.mock('../../middleware/verifyEditable.js', () => ({
+  default: () => ({
+    verifyProjectDeveloperFromCaseId: vi.fn((req, res, next) => {
+      next();
+    }),
+  }),
+}));
+
+const mockStep = { create: vi.fn(), update: vi.fn(), destroy: vi.fn() };
+const mockCaseStep = { create: vi.fn(), update: vi.fn(), destroy: vi.fn(), findAll: vi.fn() };
+
+vi.mock('../../models/steps.js', () => ({ default: () => mockStep }));
+vi.mock('../../models/caseSteps.js', () => ({ default: () => mockCaseStep }));
+
+describe('POST /steps/update', () => {
+  let app;
+  let sequelize;
+  let transactionMock;
+
+  beforeEach(() => {
+    transactionMock = { commit: vi.fn(), rollback: vi.fn() };
+    sequelize = new Sequelize({ dialect: 'sqlite', logging: false });
+    sequelize.transaction = vi.fn().mockResolvedValue(transactionMock);
+
+    app = express();
+    app.use(express.json());
+    app.use('/steps', stepEditRoute(sequelize));
+
+    vi.clearAllMocks();
+  });
+
+  it('should create a new step when editState is "new"', async () => {
+    const mockStepId = 3;
+    mockCaseStep.findAll.mockResolvedValue([]);
+    mockStep.create.mockResolvedValue({ id: mockStepId });
+    mockCaseStep.create.mockResolvedValue({});
+
+    const payload = [
+      {
+        step: 'new step',
+        result: 'new result',
+        editState: 'new',
+        caseSteps: { stepNo: 1 },
+      },
+    ];
+
+    const res = await request(app).post('/steps/update?caseId=1').send(payload);
+    expect(res.status).toBe(200);
+
+    const [stepCreateData, stepCreateOptions] = mockStep.create.mock.calls[0];
+    expect(stepCreateData).toEqual({
+      step: 'new step',
+      result: 'new result',
+    });
+    expect(stepCreateOptions.transaction).toBeDefined();
+
+    const [caseStepCreateData, caseStepCreateOptions] = mockCaseStep.create.mock.calls[0];
+    expect(caseStepCreateData).toEqual({
+      caseId: 1,
+      stepId: mockStepId,
+      stepNo: 1,
+    });
+    expect(caseStepCreateOptions.transaction).toBeDefined();
+  });
+
+  it('should update a step when editState is "changed"', async () => {
+    mockCaseStep.findAll.mockResolvedValue([]);
+    mockStep.update.mockResolvedValue([1]);
+    mockCaseStep.update.mockResolvedValue([1]);
+
+    const payload = [
+      {
+        id: 50,
+        step: 'updated step',
+        result: 'updated result',
+        editState: 'changed',
+        caseSteps: { stepNo: 2 },
+      },
+    ];
+
+    const res = await request(app).post('/steps/update?caseId=1').send(payload);
+    expect(res.status).toBe(200);
+
+    const [stepUpdateData, stepUpdateOptions] = mockStep.update.mock.calls[0];
+    expect(stepUpdateData).toEqual({ step: 'updated step', result: 'updated result' });
+    expect(stepUpdateOptions.where).toEqual({ id: 50 });
+    expect(stepUpdateOptions.transaction).toBeDefined();
+
+    const [caseStepUpdateData, caseStepUpdateOptions] = mockCaseStep.update.mock.calls[0];
+    expect(caseStepUpdateData).toEqual({ stepNo: 2 });
+    expect(caseStepUpdateOptions.where).toEqual({ caseId: 1, stepId: 50 });
+    expect(caseStepUpdateOptions.transaction).toBeDefined();
+  });
+
+  it('should not call create or update when editState is "notChanged"', async () => {
+    mockCaseStep.findAll.mockResolvedValue([{ stepId: 99 }]);
+
+    const payload = [
+      {
+        id: 99,
+        step: 'same step',
+        result: 'same result',
+        editState: 'notChanged',
+        caseSteps: { stepNo: 1 },
+      },
+    ];
+
+    const res = await request(app).post('/steps/update?caseId=1').send(payload);
+
+    expect(res.status).toBe(200);
+    expect(mockStep.create).not.toHaveBeenCalled();
+    expect(mockStep.update).not.toHaveBeenCalled();
+    expect(mockStep.destroy).not.toHaveBeenCalled();
+    expect(mockCaseStep.destroy).not.toHaveBeenCalled();
+
+    expect(res.body[0]).toEqual({
+      id: 99,
+      step: 'same step',
+      result: 'same result',
+      caseSteps: { stepNo: 1 },
+      editState: 'notChanged',
+    });
+  });
+
+  it('should handle mixed payload (new + changed + notChanged)', async () => {
+    const mockStepId = 22;
+    mockCaseStep.findAll.mockResolvedValue([{ stepId: 10 }, { stepId: 11 }]);
+
+    mockStep.create.mockResolvedValue({ id: mockStepId });
+    mockCaseStep.create.mockResolvedValue({});
+    mockStep.update.mockResolvedValue([1]);
+    mockCaseStep.update.mockResolvedValue([1]);
+
+    const payload = [
+      { step: 'new step', result: 'new result', editState: 'new', caseSteps: { stepNo: 1 } },
+      { id: 10, step: 'updated step', result: 'updated result', editState: 'changed', caseSteps: { stepNo: 2 } },
+      { id: 11, step: 'same step', result: 'same result', editState: 'notChanged', caseSteps: { stepNo: 3 } },
+    ];
+
+    const res = await request(app).post('/steps/update?caseId=1').send(payload);
+    expect(res.status).toBe(200);
+
+    expect(mockStep.create).toHaveBeenCalledTimes(1);
+    expect(mockStep.update).toHaveBeenCalledTimes(1);
+
+    // state 'new'
+    const [stepCreateData, stepCreateOptions] = mockStep.create.mock.calls[0];
+    expect(stepCreateData).toEqual({ step: 'new step', result: 'new result' });
+    expect(stepCreateOptions.transaction).toBeDefined();
+
+    const [caseStepCreateData, caseStepCreateOptions] = mockCaseStep.create.mock.calls[0];
+    expect(caseStepCreateData).toEqual({ caseId: 1, stepId: mockStepId, stepNo: 1 });
+    expect(caseStepCreateOptions.transaction).toBeDefined();
+
+    // state 'changed'
+    const [stepUpdateData, stepUpdateOptions] = mockStep.update.mock.calls[0];
+    expect(stepUpdateData).toEqual({ step: 'updated step', result: 'updated result' });
+    expect(stepUpdateOptions.where).toEqual({ id: 10 });
+    expect(stepUpdateOptions.transaction).toBeDefined();
+
+    const [caseStepUpdateData, caseStepUpdateOptions] = mockCaseStep.update.mock.calls[0];
+    expect(caseStepUpdateData).toEqual({ stepNo: 2 });
+    expect(caseStepUpdateOptions.where).toEqual({ caseId: 1, stepId: 10 });
+    expect(caseStepUpdateOptions.transaction).toBeDefined();
+  });
+
+  it('should delete removed steps', async () => {
+    mockCaseStep.findAll.mockResolvedValue([{ stepId: 1 }, { stepId: 2 }]);
+
+    const payload = [{ id: 1, editState: 'notChanged', caseSteps: { stepNo: 1 } }];
+
+    const res = await request(app).post('/steps/update?caseId=1').send(payload);
+    expect(res.status).toBe(200);
+
+    const [caseStepDestroyOptions] = mockCaseStep.destroy.mock.calls[0];
+    expect(caseStepDestroyOptions.where).toEqual({ caseId: 1, stepId: 2 });
+    expect(caseStepDestroyOptions.transaction).toBeDefined();
+
+    const [stepDestroyOptions] = mockStep.destroy.mock.calls[0];
+    expect(stepDestroyOptions.where).toEqual({ id: 2 });
+    expect(stepDestroyOptions.transaction).toBeDefined();
+  });
+});

--- a/frontend/src/app/[locale]/projects/[projectId]/folders/[folderId]/cases/[caseId]/CaseEditor.tsx
+++ b/frontend/src/app/[locale]/projects/[projectId]/folders/[folderId]/cases/[caseId]/CaseEditor.tsx
@@ -1,5 +1,5 @@
 'use client';
-import { useState, useEffect, useContext, ChangeEvent, DragEvent } from 'react';
+import { useState, useEffect, useCallback, useContext, ChangeEvent, DragEvent } from 'react';
 import { Input, Textarea, Select, SelectItem, Button, Divider, Tooltip, addToast, Badge } from '@heroui/react';
 import { Save, Plus, ArrowLeft, Circle } from 'lucide-react';
 import CaseStepsEditor from './CaseStepsEditor';
@@ -60,7 +60,6 @@ export default function CaseEditor({
   const [testCase, setTestCase] = useState<CaseType>(defaultTestCase);
   const [isTitleInvalid] = useState<boolean>(false);
   const [isUpdating, setIsUpdating] = useState<boolean>(false);
-  const [idCounter, setIdCounter] = useState<number>(0);
   const [isDirty, setIsDirty] = useState(false);
   const [selectedTags, setSelectedTags] = useState<{ id: number; name: string }[]>([]);
 
@@ -68,14 +67,9 @@ export default function CaseEditor({
   useFormGuard(isDirty, messages.areYouSureLeave);
 
   const onPlusClick = async (newStepNo: number) => {
-    if (!testCase.Steps) {
-      return;
-    }
     setIsDirty(true);
-    const nextId = idCounter + 1;
     const newStep: StepType = {
-      // hypothetical ID
-      id: nextId,
+      id: null,
       step: '',
       result: '',
       createdAt: new Date(),
@@ -83,7 +77,7 @@ export default function CaseEditor({
       caseSteps: {
         stepNo: newStepNo,
       },
-      uid: `uid${nextId}`,
+      uid: `uid-${Date.now()}-${Math.floor(Math.random() * 100000)}`,
       editState: 'new',
     };
 
@@ -107,22 +101,18 @@ export default function CaseEditor({
       ...testCase,
       Steps: updatedSteps,
     });
-    setIdCounter(nextId);
   };
 
-  const onDeleteClick = async (stepId: number) => {
+  const onDeleteClick = async (stepUid: string) => {
     setIsDirty(true);
-    if (!testCase.Steps) {
-      return;
-    }
-    // find deletedStep's stepNo
 
-    const deletedStep = testCase.Steps.find((step) => step.id === stepId);
+    const deletedStep = testCase.Steps.find((step) => step.uid === stepUid);
     if (!deletedStep) {
       return;
     }
     const deletedStepNo = deletedStep.caseSteps.stepNo;
-    deletedStep.editState = 'deleted';
+    // Delete step from array
+    testCase.Steps = testCase.Steps.filter((step) => step.uid !== stepUid);
 
     const updatedSteps = testCase.Steps.map((step) => {
       if (step.caseSteps.stepNo > deletedStepNo) {
@@ -200,19 +190,16 @@ export default function CaseEditor({
     }
   };
 
-  const onStepUpdate = (stepId: number, changeStep: StepType) => {
+  const onStepUpdate = (stepUid: string, changeStep: StepType) => {
     if (changeStep.editState === 'notChanged') {
       changeStep.editState = 'changed';
-    }
-
-    if (!testCase.Steps) {
-      return;
+      setIsDirty(true);
     }
 
     setTestCase({
       ...testCase,
       Steps: testCase.Steps.map((step) => {
-        if (step.id === stepId) {
+        if (step.uid === stepUid) {
           return changeStep;
         } else {
           return step;
@@ -221,30 +208,27 @@ export default function CaseEditor({
     });
   };
 
-  useEffect(() => {
-    const fetchAndSetCase = async () => {
-      if (!tokenContext.isSignedIn()) return;
-      try {
-        const data = await fetchCase(tokenContext.token.access_token, Number(caseId));
-        data.Steps.forEach((step: StepType) => {
-          step.editState = 'notChanged';
-        });
+  const fetchAndSetCase = useCallback(async () => {
+    if (!tokenContext.isSignedIn()) return;
+    try {
+      const data = await fetchCase(tokenContext.token.access_token, Number(caseId));
+      data.Steps.forEach((step: StepType) => {
+        step.editState = 'notChanged';
+        step.uid = `uid-${step.id}`;
+      });
 
-        // set idCounter to the max step id to avoid id conflict for new steps
-        // id is not reflected on database
-        const maxStepId = data.Steps.reduce((maxId: number, step: StepType) => Math.max(maxId, step.id), 0);
-        setIdCounter(maxStepId);
-        setTestCase(data);
-        if (data.Tags) {
-          setSelectedTags(Array.isArray(data.Tags) ? data.Tags : []);
-        }
-      } catch (error: unknown) {
-        logError('Error fetching case data', error);
+      setTestCase(data);
+      if (data.Tags) {
+        setSelectedTags(Array.isArray(data.Tags) ? data.Tags : []);
       }
-    };
-    fetchAndSetCase();
+    } catch (error: unknown) {
+      logError('Error fetching case data', error);
+    }
   }, [tokenContext, caseId]);
 
+  useEffect(() => {
+    fetchAndSetCase();
+  }, [fetchAndSetCase]);
   return (
     <>
       <div className="border-b-1 dark:border-neutral-700 w-full p-3 flex items-center justify-between">
@@ -288,6 +272,8 @@ export default function CaseEditor({
                   color: 'success',
                   description: messages.updatedTestCase,
                 });
+
+                await fetchAndSetCase();
                 setIsDirty(false);
               } catch (error) {
                 logError('Error updating test case', error);

--- a/frontend/src/app/[locale]/projects/[projectId]/folders/[folderId]/cases/[caseId]/CaseEditor.tsx
+++ b/frontend/src/app/[locale]/projects/[projectId]/folders/[folderId]/cases/[caseId]/CaseEditor.tsx
@@ -67,6 +67,8 @@ export default function CaseEditor({
   useFormGuard(isDirty, messages.areYouSureLeave);
 
   const onPlusClick = async (newStepNo: number) => {
+    if (!testCase.Steps) return;
+
     setIsDirty(true);
     const newStep: StepType = {
       id: null,
@@ -104,17 +106,15 @@ export default function CaseEditor({
   };
 
   const onDeleteClick = async (stepUid: string) => {
+    if (!testCase.Steps) return;
     setIsDirty(true);
 
     const deletedStep = testCase.Steps.find((step) => step.uid === stepUid);
-    if (!deletedStep) {
-      return;
-    }
-    const deletedStepNo = deletedStep.caseSteps.stepNo;
-    // Delete step from array
-    testCase.Steps = testCase.Steps.filter((step) => step.uid !== stepUid);
+    if (!deletedStep) return;
 
-    const updatedSteps = testCase.Steps.map((step) => {
+    const deletedStepNo = deletedStep.caseSteps.stepNo;
+
+    const updatedSteps = testCase.Steps.filter((step) => step.uid !== stepUid).map((step) => {
       if (step.caseSteps.stepNo > deletedStepNo) {
         return {
           ...step,
@@ -195,6 +195,8 @@ export default function CaseEditor({
       changeStep.editState = 'changed';
       setIsDirty(true);
     }
+
+    if (!testCase.Steps) return;
 
     setTestCase({
       ...testCase,

--- a/frontend/src/app/[locale]/projects/[projectId]/folders/[folderId]/cases/[caseId]/CaseStepsEditor.tsx
+++ b/frontend/src/app/[locale]/projects/[projectId]/folders/[folderId]/cases/[caseId]/CaseStepsEditor.tsx
@@ -24,10 +24,10 @@ export default function StepsEditor({ isDisabled, steps, onStepUpdate, onStepPlu
 
   return (
     <>
-      {filteredSteps.map((step, index) => (
-        <div key={index} className="flex items-center my-1">
+      {filteredSteps.map((step) => (
+        <div key={step.uid} className="flex items-center my-1">
           <Avatar className="me-2" size="sm" name={step.caseSteps.stepNo.toString()} />
-          <div key={step.uid} className="grow flex gap-2">
+          <div className="grow flex gap-2">
             <div className="w-1/2">
               <Textarea
                 size="sm"

--- a/frontend/src/app/[locale]/projects/[projectId]/folders/[folderId]/cases/[caseId]/CaseStepsEditor.tsx
+++ b/frontend/src/app/[locale]/projects/[projectId]/folders/[folderId]/cases/[caseId]/CaseStepsEditor.tsx
@@ -5,9 +5,9 @@ import { CaseMessages, StepType } from '@/types/case';
 type Props = {
   isDisabled: boolean;
   steps: StepType[];
-  onStepUpdate: (stepId: number, step: StepType) => void;
+  onStepUpdate: (stepUid: string, step: StepType) => void;
   onStepPlus: (newStepNo: number) => void;
-  onStepDelete: (stepId: number) => void;
+  onStepDelete: (stepUid: string) => void;
   messages: CaseMessages;
 };
 
@@ -27,7 +27,7 @@ export default function StepsEditor({ isDisabled, steps, onStepUpdate, onStepPlu
       {filteredSteps.map((step, index) => (
         <div key={index} className="flex items-center my-1">
           <Avatar className="me-2" size="sm" name={step.caseSteps.stepNo.toString()} />
-          <div key={step.id} className="grow flex gap-2">
+          <div key={step.uid} className="grow flex gap-2">
             <div className="w-1/2">
               <Textarea
                 size="sm"
@@ -35,7 +35,7 @@ export default function StepsEditor({ isDisabled, steps, onStepUpdate, onStepPlu
                 label={messages.detailsOfTheStep}
                 value={step.step}
                 onValueChange={(changeValue) => {
-                  onStepUpdate(step.id, { ...step, step: changeValue });
+                  onStepUpdate(step.uid, { ...step, step: changeValue });
                 }}
               />
             </div>
@@ -46,7 +46,7 @@ export default function StepsEditor({ isDisabled, steps, onStepUpdate, onStepPlu
                 label={messages.expectedResult}
                 value={step.result}
                 onValueChange={(changeValue) => {
-                  onStepUpdate(step.id, { ...step, result: changeValue });
+                  onStepUpdate(step.uid, { ...step, result: changeValue });
                 }}
               />
             </div>
@@ -58,7 +58,7 @@ export default function StepsEditor({ isDisabled, steps, onStepUpdate, onStepPlu
                 size="sm"
                 isDisabled={isDisabled}
                 className="bg-transparent rounded-full"
-                onPress={() => onStepDelete(step.id)}
+                onPress={() => onStepDelete(step.uid)}
               >
                 <Trash size={16} />
               </Button>

--- a/frontend/types/case.ts
+++ b/frontend/types/case.ts
@@ -10,7 +10,7 @@ type CaseType = {
   preConditions: string;
   expectedResults: string;
   folderId: number;
-  Steps?: StepType[];
+  Steps: StepType[];
   RunCases?: RunCaseType[];
   Attachments?: AttachmentType[];
   Tags?: {
@@ -28,7 +28,7 @@ type CaseStepType = {
 };
 
 type StepType = {
-  id: number;
+  id: number | null;
   step: string;
   result: string;
   createdAt: Date;

--- a/frontend/types/case.ts
+++ b/frontend/types/case.ts
@@ -10,7 +10,7 @@ type CaseType = {
   preConditions: string;
   expectedResults: string;
   folderId: number;
-  Steps: StepType[];
+  Steps?: StepType[];
   RunCases?: RunCaseType[];
   Attachments?: AttachmentType[];
   Tags?: {


### PR DESCRIPTION
This PR solves #407 and potentially #412.

While debugging this issue, I identified the following:

Frontend
When a test step was updated, the form was not being reset. As a result, if the user did not manually refresh the page and kept clicking the "Update" button, a new step would be created each time. This happened because the test step remained with `editState: 'new'`.

To fix this, `fetchAndSetCase()` is now called after every update, ensuring the form is properly reset.

Backend
In the `/api/steps/update?caseId={number}` route, I implemented logic that compares the existing test step IDs with the IDs received in the request. Any steps that exist in the database but are not present in the request are deleted.

This introduces a new approach for deleting test steps and helps prevent duplicated step numbers.

This change was necessary because relying on `editState: 'deleted'`  and `'editState: new` is not reliable in concurrent scenarios. It cannot safely handle multiple requests happening at the same time (two users, same test case) and may lead to inconsistencies in the test steps state.

Regarding #412
The issue description is not entirely clear. If the problem is related to duplicated steps, this PR should resolve it.

However, if the concern is about concurrent editing (two users editing at the same time and the last request overwriting the first), I consider this to be expected behavior.

If needed, this could be improved with solutions like WebSockets or real-time synchronization, but I'm not sure if the added complexity is justified for this project. Alternatively, this can be managed through team coordination.