### PR TITLE
feat: add step numbers to test step details in run view (#404)

### DIFF
--- a/frontend/src/app/[locale]/projects/[projectId]/runs/[runId]/cases/[caseId]/CaseDetail.tsx
+++ b/frontend/src/app/[locale]/projects/[projectId]/runs/[runId]/cases/[caseId]/CaseDetail.tsx
@@ -98,7 +98,13 @@ export default function CaseDetail({
             testCase.Steps.map((step) => (
               <div key={step.id} className="flex gap-2 my-2">
                 <div className="w-1/2">
-                  <Textarea isReadOnly size="sm" variant="flat" label={messages.detailsOfTheStep} value={step.step} />
+                  <Textarea
+                    isReadOnly
+                    size="sm"
+                    variant="flat"
+                    label={`${messages.detailsOfTheStep} ${step.caseSteps.stepNo}`}
+                    value={step.step}
+                  />
                 </div>
                 <div className="w-1/2">
                   <Textarea isReadOnly size="sm" variant="flat" label={messages.expectedResult} value={step.result} />


### PR DESCRIPTION
## Summary

Closes #404

## Problem

In the test run detail pane, when a test case uses the step-based template, all step labels showed the same text: **"Details of the step"**. With multiple steps, this made it hard to identify which step you were looking at.

## Fix

Append the step's sequence number to the label:

```
Details of the step 1
Details of the step 2
...
```

The change is in `CaseDetail.tsx` — the `label` prop for the step `Textarea` now includes `step.caseSteps.stepNo`:

```tsx
// Before
label={messages.detailsOfTheStep}

// After
label={`${messages.detailsOfTheStep} ${step.caseSteps.stepNo}`}
```

No new translation keys needed since this appends the numeric step number directly.

## Testing

1. Create a test case with multiple steps using the step-based template.
2. Add the test case to a test run.
3. Open the test run and select the case — the step labels should now show "Details of the step 1", "Details of the step 2", etc.