### PR TITLE
fix: prevent step duplication when saving from multiple tabs (#407)

### DIFF
--- a/frontend/src/app/[locale]/projects/[projectId]/folders/[folderId]/cases/[caseId]/CaseEditor.tsx
+++ b/frontend/src/app/[locale]/projects/[projectId]/folders/[folderId]/cases/[caseId]/CaseEditor.tsx
@@ -283,6 +283,24 @@ export default function CaseEditor({
                 const tagIds = selectedTags.map((tag) => tag.id);
                 await updateCaseTags(tokenContext.token.access_token, Number(caseId), tagIds, projectId);
 
+                // Re-fetch the case to get authoritative step IDs and reset editState.
+                // Without this, 'new' steps remain marked as 'new' in local state and
+                // would be re-created on a subsequent save (causing duplication).
+                const refreshed = await fetchCase(tokenContext.token.access_token, Number(caseId));
+                if (refreshed?.Steps) {
+                  const refreshedSteps = refreshed.Steps.map((step: StepType) => ({
+                    ...step,
+                    editState: 'notChanged' as const,
+                  }));
+                  refreshedSteps.sort((a: StepType, b: StepType) => a.caseSteps.stepNo - b.caseSteps.stepNo);
+                  const maxStepId = refreshedSteps.reduce(
+                    (maxId: number, step: StepType) => Math.max(maxId, step.id),
+                    0
+                  );
+                  setIdCounter(maxStepId);
+                  setTestCase((prev) => ({ ...prev, Steps: refreshedSteps }));
+                }
+
                 addToast({
                   title: 'Success',
                   color: 'success',


### PR DESCRIPTION
## Summary

Fixes #407

## Root Cause

Step duplication happened because after a successful save, the local React state was not updated to reflect the persisted steps. Steps that were created (`editState: 'new'`) remained in local state with `editState: 'new'` after the save returned successfully. Any subsequent call to **Update** (including from a duplicated browser tab that shares the same React state) would treat those steps as brand-new and insert them into the database again.

Repro steps:
1. Open a test case and add one or more new steps.
2. Click **Update** (steps are created in DB).
3. Click **Update** again without navigating away — the same "new" steps are created a second time, producing duplicates.

The same issue affects the duplicate-tab scenario, since duplicating a tab in Chrome copies the React component state including any uncommitted `editState: 'new'` steps.

## Fix

After a successful save, re-fetch the case from the server to get the authoritative step list (with real DB IDs) and mark all steps as `notChanged`:

```tsx
const refreshed = await fetchCase(tokenContext.token.access_token, Number(caseId));
if (refreshed?.Steps) {
  const refreshedSteps = refreshed.Steps.map((step: StepType) => ({
    ...step,
    editState: 'notChanged' as const,
  }));
  // … sort and update state
}
```

This ensures:
- Newly created steps receive their real DB IDs.
- All `editState` values are reset to `'notChanged'` so a re-save does not create duplicates.
- The `idCounter` is updated to the max real ID to avoid hypothetical ID collisions with future new steps.

## Testing

1. Open a test case, add two new steps, click **Update**.
2. Verify only two steps appear (no duplicates).
3. Click **Update** again without any changes — verify the step count remains unchanged.
4. Open the same test case URL in two browser tabs. Add a step in tab A and click **Update**. Then click **Update** in tab B — verify no duplicate steps are created.