### PR TITLE
feat: allow configuring bcrypt cost factor via BCRYPT_ROUNDS env var

### DIFF
--- a/backend/routes/users/adminResetPassword.js
+++ b/backend/routes/users/adminResetPassword.js
@@ -28,7 +28,8 @@ export default function (sequelize) {
         return res.status(404).send('User not found');
       }
 
-      const hashedPassword = await bcrypt.hash(newPassword, 10);
+      const bcryptRounds = parseInt(process.env.BCRYPT_ROUNDS || '10', 10);
+      const hashedPassword = await bcrypt.hash(newPassword, bcryptRounds);
       await user.update({ password: hashedPassword });
 
       return res.json({ user: { id: user.id } });

--- a/backend/routes/users/signup.js
+++ b/backend/routes/users/signup.js
@@ -13,7 +13,8 @@ export default function (sequelize) {
   router.post('/signup', async (req, res) => {
     try {
       const { email, password, username } = req.body;
-      const hashedPassword = await bcrypt.hash(password, 10);
+      const bcryptRounds = parseInt(process.env.BCRYPT_ROUNDS || '10', 10);
+      const hashedPassword = await bcrypt.hash(password, bcryptRounds);
 
       const userCount = await User.count();
       const initialRole =

--- a/backend/routes/users/updatePassword.js
+++ b/backend/routes/users/updatePassword.js
@@ -35,7 +35,8 @@ export default function (sequelize) {
       }
 
       // Hash new password
-      const hashedPassword = await bcrypt.hash(newPassword, 10);
+      const bcryptRounds = parseInt(process.env.BCRYPT_ROUNDS || '10', 10);
+      const hashedPassword = await bcrypt.hash(newPassword, bcryptRounds);
       await user.update({ password: hashedPassword });
 
       res.json({ message: 'Password updated successfully' });

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -10,6 +10,7 @@ services:
     environment:
       - PORT=8000
       - SECRET_KEY=your_secret_key_here
+      - BCRYPT_ROUNDS=10 # optional: bcrypt cost factor for password hashing (default: 10)
       - IS_DEMO=false # set to true to seed the database
       - API_PATH=${API_PATH:-/api}
     volumes:


### PR DESCRIPTION
## Summary

Fixes #391

The bcrypt cost factor (number of salt rounds) was hardcoded to `10` in three places. This PR replaces those with a configurable `BCRYPT_ROUNDS` environment variable, defaulting to `10` when not set.

## Changes

- `backend/routes/users/signup.js` — uses `BCRYPT_ROUNDS` when hashing new user passwords
- `backend/routes/users/updatePassword.js` — uses `BCRYPT_ROUNDS` when hashing updated passwords
- `backend/routes/users/adminResetPassword.js` — uses `BCRYPT_ROUNDS` when admin resets a user's password
- `docker-compose.yaml` — documents the new optional env var

## Usage

Set the environment variable before starting the backend:

```
BCRYPT_ROUNDS=12
```

Higher values increase security but slow down hashing. The default of `10` keeps backward-compatible behaviour.