### PR TITLE
feat: allow configuring max JSON request body size via MAX_REQUEST_BODY_SIZE env var

### DIFF
--- a/backend/server.ts
+++ b/backend/server.ts
@@ -21,7 +21,7 @@ const corsOptions = {
 app.use(cors(corsOptions));
 
 // enable json middleware
-app.use(express.json());
+app.use(express.json({ limit: process.env.MAX_REQUEST_BODY_SIZE || '100kb' }));
 
 // enable rate limiter
 const limiter = RateLimit({

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -10,6 +10,7 @@ services:
     environment:
       - PORT=8000
       - SECRET_KEY=your_secret_key_here
+      - MAX_REQUEST_BODY_SIZE=100kb # optional: maximum JSON request body size (default: 100kb)
       - IS_DEMO=false # set to true to seed the database
       - API_PATH=${API_PATH:-/api}
     volumes:


### PR DESCRIPTION
## Summary

Fixes #405

The `express.json()` middleware was called with no `limit` option, using Express's default of 100 KB. Clients uploading large test case descriptions or step content could receive a `PayloadTooLargeError`.

## Changes

- `backend/server.ts` — passes `{ limit: process.env.MAX_REQUEST_BODY_SIZE || '100kb' }` to `express.json()`
- `docker-compose.yaml` — documents the new optional env var

## Usage

```yaml
# docker-compose.yaml
environment:
  - MAX_REQUEST_BODY_SIZE=10mb
```

Or when running directly:

```bash
MAX_REQUEST_BODY_SIZE=10mb node dist/index.js
```

Accepted format is any value supported by the [bytes](https://www.npmjs.com/package/bytes) library (e.g. `100kb`, `1mb`, `5mb`).