### PR TITLE
feat: treat admin as owner of all projects

### DIFF
--- a/backend/middleware/verifyEditable.js
+++ b/backend/middleware/verifyEditable.js
@@ -1,5 +1,6 @@
 import { DataTypes } from 'sequelize';
-import { memberRoles } from '../routes/users/authSettings.js';
+import { roles, memberRoles } from '../routes/users/authSettings.js';
+import defineUser from '../models/users.js';
 import defineMember from '../models/members.js';
 import defineProject from '../models/projects.js';
 import defineFolder from '../models/folders.js';
@@ -12,7 +13,20 @@ export default function verifyEditableMiddleware(sequelize) {
    * Verify user has project
    * (have to be called after verifySignedIn() middleware)
    */
+  async function isAdmin(userId) {
+    const User = defineUser(sequelize, DataTypes);
+    const user = await User.findByPk(userId);
+    if (!user) return false;
+    const adminRoleIndex = roles.findIndex((entry) => entry.uid === 'administrator');
+    return user.role === adminRoleIndex;
+  }
+
   async function verifyProjectOwner(req, res, next) {
+    if (await isAdmin(req.userId)) {
+      next();
+      return;
+    }
+
     const Project = defineProject(sequelize, DataTypes);
 
     const projectId = req.params.projectId;
@@ -47,6 +61,11 @@ export default function verifyEditableMiddleware(sequelize) {
     const project = await Project.findByPk(projectId);
     if (!project) {
       return res.status(404).send('Project not found');
+    }
+
+    if (await isAdmin(req.userId)) {
+      next();
+      return;
     }
 
     if (project.userId === req.userId) {
@@ -161,6 +180,10 @@ export default function verifyEditableMiddleware(sequelize) {
   }
 
   async function isDeveloper(projectId, userId) {
+    if (await isAdmin(userId)) {
+      return true;
+    }
+
     const Project = defineProject(sequelize, DataTypes);
     const Member = defineMember(sequelize, DataTypes);
     Project.hasMany(Member, { foreignKey: 'projectId' });
@@ -294,6 +317,10 @@ export default function verifyEditableMiddleware(sequelize) {
   }
 
   async function isReporter(projectId, userId) {
+    if (await isAdmin(userId)) {
+      return true;
+    }
+
     const Project = defineProject(sequelize, DataTypes);
     const Member = defineMember(sequelize, DataTypes);
     Project.hasMany(Member, { foreignKey: 'projectId' });

--- a/backend/middleware/verifyVisible.js
+++ b/backend/middleware/verifyVisible.js
@@ -5,6 +5,8 @@ import defineFolder from '../models/folders.js';
 import defineCase from '../models/cases.js';
 import defineRun from '../models/runs.js';
 import defineRunCase from '../models/runCases.js';
+import defineUser from '../models/users.js';
+import { roles } from '../routes/users/authSettings.js';
 
 export default function verifyVisibleMiddleware(sequelize) {
   /**
@@ -164,6 +166,15 @@ export default function verifyVisibleMiddleware(sequelize) {
   }
 
   async function isVisible(projectId, userId) {
+    const User = defineUser(sequelize, DataTypes);
+    const user = await User.findByPk(userId);
+
+    // admins can see all projects
+    const adminRoleIndex = roles.findIndex((entry) => entry.uid === 'administrator');
+    if (user && user.role === adminRoleIndex) {
+      return true;
+    }
+
     const Project = defineProject(sequelize, DataTypes);
     const Member = defineMember(sequelize, DataTypes);
     Project.hasMany(Member, { foreignKey: 'projectId' });

--- a/backend/routes/projects/index.js
+++ b/backend/routes/projects/index.js
@@ -3,16 +3,24 @@ const router = express.Router();
 import { DataTypes, Op } from 'sequelize';
 import defineProject from '../../models/projects.js';
 import defineMember from '../../models/members.js';
+import defineUser from '../../models/users.js';
 import authMiddleware from '../../middleware/auth.js';
+import { roles } from '../users/authSettings.js';
 
 export default function (sequelize) {
   const { verifySignedIn } = authMiddleware(sequelize);
   const Project = defineProject(sequelize, DataTypes);
   const Member = defineMember(sequelize, DataTypes);
+  const User = defineUser(sequelize, DataTypes);
   Project.hasMany(Member, { foreignKey: 'projectId' });
 
   router.get('/', verifySignedIn, async (req, res) => {
     try {
+      // admins can see all projects
+      const user = await User.findByPk(req.userId);
+      const adminRoleIndex = roles.findIndex((entry) => entry.uid === 'administrator');
+      const isAdmin = user && user.role === adminRoleIndex;
+
       let projects;
       if (req.query.onlyUserProjects === 'true') {
         projects = await Project.findAll({
@@ -20,6 +28,8 @@ export default function (sequelize) {
             userId: req.userId,
           },
         });
+      } else if (isAdmin) {
+        projects = await Project.findAll();
       } else {
         // public projects, owned projects, participated projects will be returned
         projects = await Project.findAll({


### PR DESCRIPTION
## Summary

Fixes #401

Administrators were required to be explicit members of every project to view or modify it. This PR makes the admin role act as if they own all projects.

## Changes

### `backend/middleware/verifyVisible.js`
- Adds `defineUser` / `roles` imports
- In `isVisible()`: if the requesting user is an administrator, returns `true` immediately (before any project/member lookup)

### `backend/middleware/verifyEditable.js`
- Adds `defineUser` / `roles` imports
- Extracts a shared `isAdmin(userId)` helper
- `verifyProjectOwner`: allows admins through before checking project ownership
- `verifyProjectManagerFromProjectId`: allows admins through without checking member role
- `isDeveloper()` / `isReporter()`: allows admins before any DB query, covering all `verifyProjectDeveloper*` and `verifyProjectReporter*` middlewares

### `backend/routes/projects/index.js`
- `GET /projects`: if the requesting user is an admin, returns **all** projects (instead of only owned/member/public ones)