### PR TITLE
feat: extend case search to include preConditions, expectedResults and steps

### DIFF
--- a/backend/routes/cases/index.js
+++ b/backend/routes/cases/index.js
@@ -36,9 +36,16 @@ export default function (sequelize) {
         }
 
         if (searchTerm.length >= 1) {
+          const likePattern = `%${searchTerm}%`;
+          const escapedPattern = sequelize.escape(likePattern);
           whereClause[Op.or] = [
-            { title: { [Op.like]: `%${searchTerm}%` } },
-            { description: { [Op.like]: `%${searchTerm}%` } },
+            { title: { [Op.like]: likePattern } },
+            { description: { [Op.like]: likePattern } },
+            { preConditions: { [Op.like]: likePattern } },
+            { expectedResults: { [Op.like]: likePattern } },
+            sequelize.literal(
+              `EXISTS (SELECT 1 FROM caseSteps cs JOIN Steps s ON cs.stepId = s.id WHERE cs.caseId = \`Case\`.\`id\` AND (s.step LIKE ${escapedPattern} OR s.result LIKE ${escapedPattern}))`
+            ),
           ];
         }
       }

--- a/backend/routes/cases/indexByProjectId.js
+++ b/backend/routes/cases/indexByProjectId.js
@@ -56,9 +56,16 @@ export default function (sequelize) {
           }
 
           if (searchTerm.length >= 1) {
+            const likePattern = `%${searchTerm}%`;
+            const escapedPattern = sequelize.escape(likePattern);
             caseWhereClause[Op.or] = [
-              { title: { [Op.like]: `%${searchTerm}%` } },
-              { description: { [Op.like]: `%${searchTerm}%` } },
+              { title: { [Op.like]: likePattern } },
+              { description: { [Op.like]: likePattern } },
+              { preConditions: { [Op.like]: likePattern } },
+              { expectedResults: { [Op.like]: likePattern } },
+              sequelize.literal(
+                `EXISTS (SELECT 1 FROM caseSteps cs JOIN Steps s ON cs.stepId = s.id WHERE cs.caseId = \`Case\`.\`id\` AND (s.step LIKE ${escapedPattern} OR s.result LIKE ${escapedPattern}))`
+              ),
             ];
           }
         }


### PR DESCRIPTION
## Summary

Extends the test case search to also match against `preConditions`, `expectedResults`, and step content (`step`/`result` fields), so users can find cases by searching through the full details of each test case.

## Changes

- **`backend/routes/cases/index.js`** (folder-level case listing): Extended `Op.or` search to include `preConditions`, `expectedResults`, and a subquery checking Steps content
- **`backend/routes/cases/indexByProjectId.js`** (project-level case listing used in test run selector): Same extension

The step search uses a SQL subquery via `sequelize.literal` with `sequelize.escape()` to safely handle user input:
```sql
EXISTS (
  SELECT 1 FROM caseSteps cs 
  JOIN Steps s ON cs.stepId = s.id 
  WHERE cs.caseId = `Case`.`id` 
    AND (s.step LIKE ? OR s.result LIKE ?)
)
```

Closes #347