### PR TITLE
fix OIDC in a built version

### DIFF
--- a/backend/config/config.js
+++ b/backend/config/config.js
@@ -1,4 +1,12 @@
 import path from 'path';
+import { defaultDangerKey } from '../routes/users/authSettings.js';
+
+export const FRONTEND_ORIGIN = process.env.FRONTEND_ORIGIN || 'http://localhost:8000';
+export const SECRET_KEY = process.env.SECRET_KEY || defaultDangerKey;
+
+export const IS_PROD = process.env.NODE_ENV === 'production';
+export const PORT = process.env.PORT || 8001;
+export const API_PATH = process.env.API_PATH || '/api';
 
 const databasePath = process.env.DATABASE_PATH ?? path.resolve(process.cwd(), 'database/database.sqlite');
 

--- a/backend/index.ts
+++ b/backend/index.ts
@@ -1,6 +1,5 @@
 import server from './server.js';
-
-const PORT = process.env.PORT || 8001;
+import { PORT } from './config/config.js';
 
 server.listen(PORT, () => {
   console.log(`Backend server is running on port ${PORT}`);

--- a/backend/routes/users/oidc.js
+++ b/backend/routes/users/oidc.js
@@ -3,21 +3,19 @@ import { auth } from 'express-openid-connect';
 import jwt from 'jsonwebtoken';
 import { DataTypes } from 'sequelize';
 import defineUser from '../../models/users.js';
-import { roles, defaultDangerKey } from './authSettings.js';
+import { API_PATH, FRONTEND_ORIGIN, IS_PROD, PORT, SECRET_KEY } from '../../config/config.js';
+import { roles } from './authSettings.js';
 
 const router = express.Router();
 
 export default function (sequelize) {
   const User = defineUser(sequelize, DataTypes);
-  const secretKey = process.env.SECRET_KEY || defaultDangerKey;
-  const frontendOrigin = process.env.FRONTEND_ORIGIN || 'http://localhost:8000';
-  const signInURL = `${frontendOrigin}/account/signin`;
+
+  const signInURL = `${FRONTEND_ORIGIN}/account/signin`;
+  const apiOrigin = IS_PROD ? `${FRONTEND_ORIGIN}${API_PATH}` : `http://localhost:${PORT}`;
 
   const isOIDCConfigured =
-    process.env.OIDC_ISSUER != null &&
-    process.env.OIDC_CLIENT_ID != null &&
-    process.env.OIDC_CLIENT_SECRET != null &&
-    process.env.OIDC_CALLBACK_URL != null;
+    process.env.OIDC_ISSUER != null && process.env.OIDC_CLIENT_ID != null && process.env.OIDC_CLIENT_SECRET != null;
 
   router.get('/oidc/enabled', (req, res) => {
     res.json({ enabled: isOIDCConfigured });
@@ -29,9 +27,9 @@ export default function (sequelize) {
 
   const config = {
     authRequired: false,
-    secret: secretKey,
+    secret: SECRET_KEY,
     clientSecret: process.env.OIDC_CLIENT_SECRET,
-    baseURL: process.env.OIDC_CALLBACK_URL.replace('/oidc/callback', ''),
+    baseURL: `${apiOrigin}/users`,
     clientID: process.env.OIDC_CLIENT_ID,
     issuerBaseURL: process.env.OIDC_ISSUER,
     authorizationParams: {
@@ -42,7 +40,7 @@ export default function (sequelize) {
     routes: {
       login: false, // We'll handle this manually
       callback: '/oidc/callback',
-      postLogoutRedirect: frontendOrigin,
+      postLogoutRedirect: FRONTEND_ORIGIN,
     },
   };
 
@@ -52,9 +50,9 @@ export default function (sequelize) {
   // Manual login route to redirect to OIDC provider
   router.get('/oidc/login', (req, res) => {
     res.oidc.login({
-      returnTo: '/users/oidc/afterCallback',
+      returnTo: `${apiOrigin}/users/oidc/afterCallback`,
       authorizationParams: {
-        redirect_uri: process.env.OIDC_CALLBACK_URL,
+        redirect_uri: `${apiOrigin}/users/oidc/callback`,
       },
     });
   });
@@ -92,7 +90,7 @@ export default function (sequelize) {
       }
 
       // Generate JWT token (same as regular signin)
-      const accessToken = jwt.sign({ userId: user.id }, secretKey, {
+      const accessToken = jwt.sign({ userId: user.id }, SECRET_KEY, {
         expiresIn: '24h',
       });
       const expiresAt = Date.now() + 3600 * 1000 * 24; // expire date(ms)
@@ -107,7 +105,7 @@ export default function (sequelize) {
       };
 
       const tokenParam = encodeURIComponent(JSON.stringify(tokenData));
-      res.redirect(`${frontendOrigin}/account/sso-callback?token=${tokenParam}`);
+      res.redirect(`${FRONTEND_ORIGIN}/account/sso-callback?token=${tokenParam}`);
     } catch (error) {
       console.error('OIDC authentication error:', error);
       res.redirect(signInURL);

--- a/backend/server.ts
+++ b/backend/server.ts
@@ -7,15 +7,15 @@ import cors from 'cors';
 import RateLimit from 'express-rate-limit';
 import { Sequelize } from 'sequelize';
 import { RegisterRoutes } from './routes.js';
+import { FRONTEND_ORIGIN } from './config/config.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const app: Application = express();
 
 // enable frontend access
-const frontendOrigin = process.env.FRONTEND_ORIGIN || 'http://localhost:8000';
 const corsOptions = {
-  origin: frontendOrigin,
+  origin: FRONTEND_ORIGIN,
   methods: 'GET,HEAD,PUT,PATCH,POST,DELETE',
 };
 app.use(cors(corsOptions));

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -12,6 +12,7 @@ services:
       - SECRET_KEY=your_secret_key_here
       - IS_DEMO=false # set to true to seed the database
       - API_PATH=${API_PATH:-/api}
+      - FRONTEND_ORIGIN=${FRONTEND_ORIGIN:-http://localhost:8000}
     volumes:
       - db-data:/app/backend/database
       - ./backend/public/uploads:/app/backend/public/uploads

--- a/docs/docs/getstarted/oidc.md
+++ b/docs/docs/getstarted/oidc.md
@@ -16,12 +16,12 @@ OIDC authentication is configured through environment variables. You need to pro
 
 ### Environment Variables
 
-| Variable | Description | Example                                       |
-|----------|-------------|-----------------------------------------------|
-| `OIDC_ISSUER` | The issuer base URL of your OIDC provider | `https://your-keycloak.com/realms/your-realm` |
-| `OIDC_CLIENT_ID` | The client ID from your OIDC provider | `unittcms-client`                             |
-| `OIDC_CLIENT_SECRET` | The client secret from your OIDC provider | `your-secret-here`                            |
-| `OIDC_CALLBACK_URL` | The backend callback URL where OIDC will redirect | `http://localhost:8001/users/oidc/callback`   |
+| Variable | Description                                 | Example                                       |
+|----------|---------------------------------------------|-----------------------------------------------|
+| `OIDC_ISSUER` | The issuer base URL of your OIDC provider   | `https://your-keycloak.com/realms/your-realm` |
+| `OIDC_CLIENT_ID` | The client ID from your OIDC provider       | `unittcms-client`                             |
+| `OIDC_CLIENT_SECRET` | The client secret from your OIDC provider   | `your-secret-here`                            |
+| `FRONTEND_ORIGIN` | FQDN or IP address where UnitTCMS is hosted | `https://my.domain.tld`                       |
 
 :::info
 All four environment variables must be set for OIDC authentication to be enabled. If any variable is missing, the SSO button will not appear.
@@ -42,17 +42,17 @@ services:
       - PORT=8000
       - SECRET_KEY=your_secret_key_here
       // highlight-start
+      - FRONTEND_ORIGIN=http://localhost:8000
       - OIDC_ISSUER=https://your-keycloak.com/realms/your-realm
       - OIDC_CLIENT_ID=unittcms-client
       - OIDC_CLIENT_SECRET=your-client-secret
-      - OIDC_CALLBACK_URL=http://localhost:8000/users/oidc/callback
       // highlight-end
     volumes:
       - db-data:/app/backend/database
 ```
 
 :::warning
-Make sure to update the `OIDC_CALLBACK_URL` to match your deployment URL in production.
+Make sure to update the `FRONTEND_ORIGIN` to match your deployment URL in production.
 :::
 
 ## From Source Setup
@@ -68,7 +68,6 @@ SECRET_KEY=your-secret-key
 OIDC_ISSUER=https://your-keycloak.com/realms/your-realm
 OIDC_CLIENT_ID=unittcms-client
 OIDC_CLIENT_SECRET=your-client-secret
-OIDC_CALLBACK_URL=http://localhost:3001/users/oidc/callback
 ```
 
 ## OIDC Provider Setup
@@ -80,7 +79,7 @@ You need to configure your OIDC provider to allow authentication from UnitTCMS. 
 1. **Client Type**: Confidential
 2. **Protocol**: OpenID Connect
 3. **Grant Type**: Authorization Code
-4. **Valid Redirect URIs**: `http://localhost:3001/users/oidc/callback` (update for production)
+4. **Valid Redirect URIs**: `http://localhost:8001/users/oidc/callback` (update for production)
 5. **Scopes**: `openid`, `profile`, `email`
 
 ### Example: Keycloak
@@ -92,7 +91,7 @@ You need to configure your OIDC provider to allow authentication from UnitTCMS. 
    - **Client ID**: `unittcms-client`
    - **Client Protocol**: `openid-connect`
    - **Access Type**: `confidential`
-   - **Valid Redirect URIs**: `http://localhost:3001/users/oidc/callback`
+   - **Valid Redirect URIs**: `http://localhost:8001/users/oidc/callback`
 5. Click **Save**
 6. Go to the **Credentials** tab and copy the **Client Secret**
 7. Ensure the following scopes are enabled:

--- a/entrypoint.js
+++ b/entrypoint.js
@@ -9,6 +9,7 @@ const __dirname = path.dirname(__filename);
 
 // Use express from backend node_modules
 import expressModule from './backend/node_modules/express/index.js';
+import { API_PATH, IS_PROD } from './backend/config/config.js';
 const express = expressModule.default || expressModule;
 
 async function runMigrations() {
@@ -42,9 +43,9 @@ async function startServer() {
     // Import the backend app
     const backendAppModule = await import('./backend/server.js');
     const backendApp = backendAppModule.default || backendAppModule;
-    const apiPath = process.env.API_PATH || '/api';
-    console.log(`Mounting backend API at: ${apiPath}`);
-    server.use(apiPath, backendApp);
+
+    console.log(`Mounting backend API at: ${API_PATH}`);
+    server.use(API_PATH, backendApp);
 
     // For Next.js standalone build
     // Check if we have the Next.js server file
@@ -55,7 +56,7 @@ async function startServer() {
       const next = nextModule.default || nextModule;
 
       // Initialize Next.js app
-      const dev = process.env.NODE_ENV !== 'production';
+      const dev = !IS_PROD;
       const nextApp = next({ dev, dir: path.join(__dirname, '.') });
       const handle = nextApp.getRequestHandler();
       await nextApp.prepare();

--- a/frontend/config/config.ts
+++ b/frontend/config/config.ts
@@ -1,5 +1,21 @@
 const Config = {
-  apiServer: process.env.NEXT_PUBLIC_BACKEND_ORIGIN || '/api',
+  get isProduction() {
+    return process.env.NODE_ENV === 'production';
+  },
+
+  get apiServer() {
+    const isSSR = typeof window === 'undefined';
+
+    // we are in production build with SSR enabled
+    if (isSSR && Config.isProduction) {
+      const PORT = process.env.PORT || 8000;
+      const apiPath = process.env.API_PATH || '/api';
+
+      return `http://localhost:${PORT}${apiPath}`;
+    }
+
+    return process.env.NEXT_PUBLIC_BACKEND_ORIGIN || '/api';
+  },
 
   // set 'NEXT_PUBLIC_IS_DEMO=true' in frontend/.env
   isDemoSite: process.env.NEXT_PUBLIC_IS_DEMO === 'true' || false,

--- a/frontend/src/app/[locale]/account/sso-callback/page.tsx
+++ b/frontend/src/app/[locale]/account/sso-callback/page.tsx
@@ -1,21 +1,24 @@
 'use client';
 
-import { useContext, useLayoutEffect } from 'react';
-import { useRouter, useSearchParams } from 'next/navigation';
+import { useContext, useEffect } from 'react';
+import { useSearchParams } from 'next/navigation';
 import { TokenContext } from '@/utils/TokenProvider';
+import { LocaleCodeType } from '@/types/locale';
+import { useRouter } from '@/src/i18n/routing';
 
-export default function SSOCallbackPage() {
+export default function SSOCallbackPage({ params: { locale } }: { params: { locale: LocaleCodeType } }) {
   const router = useRouter();
   const searchParams = useSearchParams();
   const context = useContext(TokenContext);
 
-  useLayoutEffect(() => {
+  // This needs to be evaluated only once
+  useEffect(() => {
     try {
       const tokenParam = searchParams.get('token');
 
       if (!tokenParam) {
         console.error('No token provided in callback');
-        router.replace('/account/signin');
+        router.replace(`/account/signin`, { locale: locale });
         return;
       }
 
@@ -24,12 +27,15 @@ export default function SSOCallbackPage() {
       context.setToken(tokenData);
       context.storeTokenToLocalStorage(tokenData);
 
-      router.replace('/projects');
+      const userLocale = tokenData.user.locale ?? locale;
+
+      router.replace(`/projects`, { locale: userLocale });
     } catch (error) {
       console.error('Error processing SSO callback:', error);
-      router.replace('/account/signin');
+      router.replace(`/account/signin`, { locale: locale });
     }
-  }, [context, router, searchParams]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   return <></>;
 }

--- a/frontend/utils/TokenProvider.tsx
+++ b/frontend/utils/TokenProvider.tsx
@@ -1,5 +1,5 @@
 'use client';
-import { createContext, useState, useEffect } from 'react';
+import { createContext, useState, useEffect, useCallback } from 'react';
 import { addToast } from '@heroui/react';
 import {
   isSignedIn as tokenIsSinedIn,
@@ -88,8 +88,8 @@ const TokenProvider = ({ toastMessages, locale, children }: TokenProps) => {
     return tokenIsProjectReporter(projectRoles, projectId);
   };
 
-  async function refreshProjectRoles() {
-    if (!hasRestoreFinished || !token || !token.access_token) {
+  const refreshProjectRoles = useCallback(async () => {
+    if (!hasRestoreFinished || !token?.access_token) {
       return;
     }
 
@@ -99,7 +99,7 @@ const TokenProvider = ({ toastMessages, locale, children }: TokenProps) => {
     } catch (error: unknown) {
       logError('Error fetching project roles', error);
     }
-  }
+  }, [hasRestoreFinished, token?.access_token]);
 
   const tokenContext = {
     token,
@@ -161,8 +161,7 @@ const TokenProvider = ({ toastMessages, locale, children }: TokenProps) => {
 
   useEffect(() => {
     refreshProjectRoles();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [hasRestoreFinished, token]);
+  }, [refreshProjectRoles]);
 
   return <TokenContext.Provider value={tokenContext}>{children}</TokenContext.Provider>;
 };

--- a/frontend/utils/ssoAvailable.ts
+++ b/frontend/utils/ssoAvailable.ts
@@ -3,8 +3,13 @@ import Config from '@/config/config';
 const apiServer = Config.apiServer;
 
 export async function fetchSSOEnabled() {
-  const res = await fetch(`${apiServer}/users/oidc/enabled`);
-  const data = await res.json();
+  try {
+    const res = await fetch(`${apiServer}/users/oidc/enabled`);
+    const data = await res.json();
 
-  return data.enabled;
+    return data.enabled ?? false;
+  } catch (e) {
+    console.error('Failed to fetch SSO status', e);
+    return false;
+  }
 }


### PR DESCRIPTION
In #419 OIDC Login was introduced, but it was not working when built with docker. 

Main culprits were:

- NextJS server is running in SSR mode
- URL of backend changes when running in docker

I've fixed small bug in `TokenProvider` with `refreshProjectRoles` as well. Becaseuse of  dependencies in `useEffect` after SSO login, it was re-fetching `/members/check` endlessly.