### PR TITLE
chore: Improve test run page's table visibility

### DIFF
--- a/frontend/src/app/[locale]/projects/[projectId]/runs/[runId]/AssigneePicker.tsx
+++ b/frontend/src/app/[locale]/projects/[projectId]/runs/[runId]/AssigneePicker.tsx
@@ -6,6 +6,7 @@ import UserAvatar from '@/components/UserAvatar';
 import { MemberType } from '@/types/user';
 
 type Props = {
+  isAvatarOnly?: boolean;
   assigneeUserId: number | null | undefined;
   members: MemberType[];
   isDisabled: boolean;
@@ -16,6 +17,7 @@ type Props = {
 };
 
 export default function AssigneePicker({
+  isAvatarOnly,
   assigneeUserId,
   members,
   isDisabled,
@@ -42,10 +44,9 @@ export default function AssigneePicker({
 
   if (isDisabled) {
     return (
-      <span className="text-sm text-default-500 flex items-center gap-1">
+      <Button isIconOnly radius="full" size="sm" variant="light" title={assigneeName}>
         <UserAvatar size={14} username={currentMember?.User?.username} avatarPath={currentMember?.User?.avatarPath} />
-        {assigneeName}
-      </span>
+      </Button>
     );
   }
 
@@ -56,20 +57,31 @@ export default function AssigneePicker({
       }}
     >
       <DropdownTrigger>
-        <Button
-          size="sm"
-          variant="light"
-          endContent={<ChevronDown size={14} />}
-          startContent={
+        {isAvatarOnly ? (
+          <Button isIconOnly radius="full" size="sm" variant="light" title={assigneeName}>
             <UserAvatar
               size={14}
               username={currentMember?.User?.username}
               avatarPath={currentMember?.User?.avatarPath}
             />
-          }
-        >
-          <span className="max-w-24 truncate">{assigneeName}</span>
-        </Button>
+          </Button>
+        ) : (
+          <Button
+            isIconOnly={isAvatarOnly}
+            size="sm"
+            variant="bordered"
+            endContent={<ChevronDown size={14} />}
+            startContent={
+              <UserAvatar
+                size={14}
+                username={currentMember?.User?.username}
+                avatarPath={currentMember?.User?.avatarPath}
+              />
+            }
+          >
+            <span className="max-w-24 truncate">{assigneeName}</span>
+          </Button>
+        )}
       </DropdownTrigger>
       <DropdownMenu
         aria-label="Select assignee"

--- a/frontend/src/app/[locale]/projects/[projectId]/runs/[runId]/RunEditor.tsx
+++ b/frontend/src/app/[locale]/projects/[projectId]/runs/[runId]/RunEditor.tsx
@@ -515,6 +515,18 @@ export default function RunEditor({
           <div className="flex items-center gap-2">
             {(selectedKeys === 'all' || selectedKeys.size > 0) && (
               <>
+                {isManager && (
+                  <AssigneePicker
+                    isAvatarOnly={false}
+                    assigneeUserId={null}
+                    members={members}
+                    isDisabled={false}
+                    unassignedLabel={messages.unassigned}
+                    searchPlaceholder={messages.searchAssignee}
+                    triggerLabel={messages.assignSelected}
+                    onAssign={(userId) => handleBulkAssignCases(userId)}
+                  />
+                )}
                 <Dropdown>
                   <DropdownTrigger>
                     <Button
@@ -543,17 +555,6 @@ export default function RunEditor({
                     </DropdownItem>
                   </DropdownMenu>
                 </Dropdown>
-                {isManager && (
-                  <AssigneePicker
-                    assigneeUserId={null}
-                    members={members}
-                    isDisabled={false}
-                    unassignedLabel={messages.unassigned}
-                    searchPlaceholder={messages.searchAssignee}
-                    triggerLabel={messages.assignSelected}
-                    onAssign={(userId) => handleBulkAssignCases(userId)}
-                  />
-                )}
               </>
             )}
           </div>

--- a/frontend/src/app/[locale]/projects/[projectId]/runs/[runId]/TestCaseSelector.tsx
+++ b/frontend/src/app/[locale]/projects/[projectId]/runs/[runId]/TestCaseSelector.tsx
@@ -100,7 +100,7 @@ export default function TestCaseSelector({
 
   const sortedItems = useMemo(() => {
     return [...cases].sort((a: CaseType, b: CaseType) => {
-      let first, second;
+      let first: number | string, second: number | string;
 
       switch (sortDescriptor.column) {
         case 'runStatus':
@@ -114,6 +114,10 @@ export default function TestCaseSelector({
         case 'priority':
           first = a.priority;
           second = b.priority;
+          break;
+        case 'assignee':
+          first = a.RunCases && a.RunCases.length > 0 ? a.RunCases[0].assigneeUserId || -1 : -1;
+          second = b.RunCases && b.RunCases.length > 0 ? b.RunCases[0].assigneeUserId || -1 : -1;
           break;
         case 'id':
         default:

--- a/frontend/src/app/[locale]/projects/[projectId]/runs/[runId]/TestCaseSelector.tsx
+++ b/frontend/src/app/[locale]/projects/[projectId]/runs/[runId]/TestCaseSelector.tsx
@@ -15,7 +15,7 @@ import {
   SortDescriptor,
   Chip,
 } from '@heroui/react';
-import { ChevronDown, MoreVertical, CopyPlus, CopyMinus, MessageCircle } from 'lucide-react';
+import { MoreVertical, CopyPlus, CopyMinus, MessageCircle } from 'lucide-react';
 import RunCaseStatus from './RunCaseStatus';
 import AssigneePicker from './AssigneePicker';
 import { Link, NextUiLinkClasses } from '@/src/i18n/routing';
@@ -72,7 +72,7 @@ export default function TestCaseSelector({
     { name: messages.priority, uid: 'priority', sortable: true },
     { name: messages.tags, uid: 'tags', sortable: false },
     { name: messages.status, uid: 'runStatus', sortable: true },
-    { name: messages.assignee, uid: 'assignee', sortable: false },
+    { name: messages.assignee, uid: 'assignee', sortable: true },
     { name: messages.comments, uid: 'comments', sortable: false },
     { name: messages.actions, uid: 'actions' },
   ];
@@ -100,8 +100,28 @@ export default function TestCaseSelector({
 
   const sortedItems = useMemo(() => {
     return [...cases].sort((a: CaseType, b: CaseType) => {
-      const first = a[sortDescriptor.column as keyof CaseType] as number;
-      const second = b[sortDescriptor.column as keyof CaseType] as number;
+      let first, second;
+
+      switch (sortDescriptor.column) {
+        case 'runStatus':
+          first = a.RunCases && a.RunCases.length > 0 ? a.RunCases[0].status : -1;
+          second = b.RunCases && b.RunCases.length > 0 ? b.RunCases[0].status : -1;
+          break;
+        case 'title':
+          first = a.title;
+          second = b.title;
+          break;
+        case 'priority':
+          first = a.priority;
+          second = b.priority;
+          break;
+        case 'id':
+        default:
+          first = a.id;
+          second = b.id;
+          break;
+      }
+
       const cmp = first < second ? -1 : first > second ? 1 : 0;
 
       return sortDescriptor.direction === 'descending' ? -cmp : cmp;
@@ -134,7 +154,7 @@ export default function TestCaseSelector({
             <Link
               href={`/projects/${projectId}/runs/${runId}/cases/${testCase.id}`}
               locale={locale}
-              className={NextUiLinkClasses}
+              className={`${NextUiLinkClasses} block max-w-24 truncate`}
               onPointerDown={(e) => e.stopPropagation()}
             >
               {cellValue as string}
@@ -166,15 +186,14 @@ export default function TestCaseSelector({
           <Dropdown>
             <DropdownTrigger>
               <Button
+                isIconOnly
+                radius="full"
                 size="sm"
                 variant="light"
+                title={isIncluded ? testRunCaseStatusMessages[testRunCaseStatus[runStatus].uid] : undefined}
                 isDisabled={!isIncluded}
-                startContent={isIncluded && <RunCaseStatus uid={testRunCaseStatus[runStatus].uid} />}
-                endContent={isIncluded && <ChevronDown size={16} />}
               >
-                <span className="w-12">
-                  {isIncluded && testRunCaseStatusMessages[testRunCaseStatus[runStatus].uid]}
-                </span>
+                {isIncluded ? <RunCaseStatus uid={testRunCaseStatus[runStatus].uid} /> : '-'}
               </Button>
             </DropdownTrigger>
             <DropdownMenu disabledKeys={disabledStatusKeys} aria-label="test case actions">
@@ -199,6 +218,7 @@ export default function TestCaseSelector({
         }
         return (
           <AssigneePicker
+            isAvatarOnly={true}
             assigneeUserId={currentAssignee ?? null}
             members={members}
             isDisabled={!isManager}


### PR DESCRIPTION
The `testCaseSelector` in `RunEditor.ts` has too many columns, exceeding the width of the display area and requiring horizontal scrolling.

I improve table's visibility by displaying only icons, truncating the content.
