### PR TITLE
feat: extend case search to include preConditions, expectedResults and steps

### DIFF
--- a/backend/routes/cases/index.js
+++ b/backend/routes/cases/index.js
@@ -36,9 +36,16 @@ export default function (sequelize) {
         }
 
         if (searchTerm.length >= 1) {
+          const likePattern = `%${searchTerm}%`;
+          const escapedPattern = sequelize.escape(likePattern);
           whereClause[Op.or] = [
-            { title: { [Op.like]: `%${searchTerm}%` } },
-            { description: { [Op.like]: `%${searchTerm}%` } },
+            { title: { [Op.like]: likePattern } },
+            { description: { [Op.like]: likePattern } },
+            { preConditions: { [Op.like]: likePattern } },
+            { expectedResults: { [Op.like]: likePattern } },
+            sequelize.literal(
+              `EXISTS (SELECT 1 FROM caseSteps cs JOIN Steps s ON cs.stepId = s.id WHERE cs.caseId = \`Case\`.\`id\` AND (s.step LIKE ${escapedPattern} OR s.result LIKE ${escapedPattern}))`
+            ),
           ];
         }
       }

--- a/backend/routes/cases/indexByProjectId.js
+++ b/backend/routes/cases/indexByProjectId.js
@@ -56,9 +56,16 @@ export default function (sequelize) {
           }
 
           if (searchTerm.length >= 1) {
+            const likePattern = `%${searchTerm}%`;
+            const escapedPattern = sequelize.escape(likePattern);
             caseWhereClause[Op.or] = [
-              { title: { [Op.like]: `%${searchTerm}%` } },
-              { description: { [Op.like]: `%${searchTerm}%` } },
+              { title: { [Op.like]: likePattern } },
+              { description: { [Op.like]: likePattern } },
+              { preConditions: { [Op.like]: likePattern } },
+              { expectedResults: { [Op.like]: likePattern } },
+              sequelize.literal(
+                `EXISTS (SELECT 1 FROM caseSteps cs JOIN Steps s ON cs.stepId = s.id WHERE cs.caseId = \`Case\`.\`id\` AND (s.step LIKE ${escapedPattern} OR s.result LIKE ${escapedPattern}))`
+              ),
             ];
           }
         }


### PR DESCRIPTION
Fixes #347

Search previously only matched on case title/description. This extends the search query to also match preConditions, expectedResults, and step text/expected-result content.