### PR TITLE
feat: allow configuring max JSON request body size via env var

### DIFF
--- a/backend/server.ts
+++ b/backend/server.ts
@@ -21,7 +21,7 @@ const corsOptions = {
 app.use(cors(corsOptions));
 
 // enable json middleware
-app.use(express.json());
+app.use(express.json({ limit: process.env.MAX_REQUEST_BODY_SIZE || '100kb' }));
 
 // enable rate limiter
 const limiter = RateLimit({

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -10,6 +10,7 @@ services:
     environment:
       - PORT=8000
       - SECRET_KEY=your_secret_key_here
+      - MAX_REQUEST_BODY_SIZE=100kb # optional: maximum JSON request body size (default: 100kb)
       - IS_DEMO=false # set to true to seed the database
       - API_PATH=${API_PATH:-/api}
     volumes:


### PR DESCRIPTION
Fixes #405

The Express JSON body size limit was hardcoded. This adds a MAX_REQUEST_BODY_SIZE env var (documented in docker-compose.yaml) so deployments with larger attachments/imports can raise the limit without a code change.