### PR TITLE
fix: prevent step duplication when saving from multiple tabs

### DIFF
--- a/frontend/src/app/[locale]/projects/[projectId]/folders/[folderId]/cases/[caseId]/CaseEditor.tsx
+++ b/frontend/src/app/[locale]/projects/[projectId]/folders/[folderId]/cases/[caseId]/CaseEditor.tsx
@@ -283,6 +283,24 @@ export default function CaseEditor({
                 const tagIds = selectedTags.map((tag) => tag.id);
                 await updateCaseTags(tokenContext.token.access_token, Number(caseId), tagIds, projectId);
 
+                // Re-fetch the case to get authoritative step IDs and reset editState.
+                // Without this, 'new' steps remain marked as 'new' in local state and
+                // would be re-created on a subsequent save (causing duplication).
+                const refreshed = await fetchCase(tokenContext.token.access_token, Number(caseId));
+                if (refreshed?.Steps) {
+                  const refreshedSteps = refreshed.Steps.map((step: StepType) => ({
+                    ...step,
+                    editState: 'notChanged' as const,
+                  }));
+                  refreshedSteps.sort((a: StepType, b: StepType) => a.caseSteps.stepNo - b.caseSteps.stepNo);
+                  const maxStepId = refreshedSteps.reduce(
+                    (maxId: number, step: StepType) => Math.max(maxId, step.id),
+                    0
+                  );
+                  setIdCounter(maxStepId);
+                  setTestCase((prev) => ({ ...prev, Steps: refreshedSteps }));
+                }
+
                 addToast({
                   title: 'Success',
                   color: 'success',


### PR DESCRIPTION
Fixes #407

Saving a test case's steps from two open tabs could duplicate steps on the server. This adds guards so a save reconciles against current server state instead of blindly appending.