### PR TITLE
fix: resolve OIDC SSR URL error and SQLITE_BUSY locking

### DIFF
--- a/backend/config/config.js
+++ b/backend/config/config.js
@@ -10,17 +10,22 @@ export const API_PATH = process.env.API_PATH || '/api';
 
 const databasePath = process.env.DATABASE_PATH ?? path.resolve(process.cwd(), 'database/database.sqlite');
 
+const sqliteOptions = {
+  dialect: 'sqlite',
+  storage: databasePath,
+  dialectOptions: {
+    busyTimeout: 5000,
+  },
+  pool: {
+    max: 1,
+    min: 0,
+    acquire: 10000,
+    idle: 10000,
+  },
+};
+
 export default {
-  development: {
-    dialect: 'sqlite',
-    storage: databasePath,
-  },
-  test: {
-    dialect: 'sqlite',
-    storage: databasePath,
-  },
-  production: {
-    dialect: 'sqlite',
-    storage: databasePath,
-  },
+  development: { ...sqliteOptions },
+  test: { ...sqliteOptions },
+  production: { ...sqliteOptions },
 };

--- a/backend/server.ts
+++ b/backend/server.ts
@@ -46,7 +46,19 @@ export const sequelize = new Sequelize({
   dialect: 'sqlite',
   storage: databasePath,
   logging: false,
+  dialectOptions: {
+    busyTimeout: 5000,
+  },
+  pool: {
+    max: 1,
+    min: 0,
+    acquire: 10000,
+    idle: 10000,
+  },
 });
+
+// Enable WAL mode for better concurrent read/write performance
+sequelize.query('PRAGMA journal_mode=WAL;').catch(() => {});
 
 // Register TSOA-generated routes (TypeScript controllers)
 RegisterRoutes(app);

--- a/frontend/utils/ssoAvailable.ts
+++ b/frontend/utils/ssoAvailable.ts
@@ -1,15 +1,28 @@
 import Config from '@/config/config';
 
-const apiServer = Config.apiServer;
+function getAbsoluteApiServer() {
+  const apiServer = Config.apiServer;
+  // In SSR (server components), relative URLs like '/api' fail with fetch().
+  // Use FRONTEND_ORIGIN or fallback to localhost to build an absolute URL.
+  if (typeof window === 'undefined' && apiServer.startsWith('/')) {
+    const origin = process.env.FRONTEND_ORIGIN || `http://localhost:${process.env.PORT || 8000}`;
+    return `${origin}${apiServer}`;
+  }
+  return apiServer;
+}
 
 export async function fetchSSOEnabled() {
   try {
-    const res = await fetch(`${apiServer}/users/oidc/enabled`);
-    const data = await res.json();
-
-    return data.enabled ?? false;
+    try {
+    const res = await fetch(`${getAbsoluteApiServer()}/users/oidc/enabled`);
+      const data = await res.json();
+      return data.enabled ?? false;
   } catch (e) {
     console.error('Failed to fetch SSO status', e);
+    return false;
+  }
+  } catch {
+    // OIDC not configured or backend unreachable during SSR — default to disabled
     return false;
   }
 }


### PR DESCRIPTION
Related to #368

Two reliability fixes found while exercising the OIDC login flow:
- `ssoAvailable.ts` was using a relative URL for its server-side fetch, which throws during SSR; now uses an absolute URL and catches fetch errors gracefully instead of crashing the page.
- Under concurrent request load, SQLite would throw SQLITE_BUSY. Enables WAL mode and sets a busyTimeout (5000ms) plus a bounded connection pool (max=1) to serialize writes instead of failing.