### PR TITLE
feat: add PostgreSQL backend support alongside SQLite

### DIFF
--- a/backend/config/config.js
+++ b/backend/config/config.js
@@ -10,11 +10,25 @@ export const API_PATH = process.env.API_PATH || '/api';
 
 const databasePath = process.env.DATABASE_PATH ?? path.resolve(process.cwd(), 'database/database.sqlite');
 
-// DB_DIALECT: 'sqlite' (default) or 'postgres'. Postgres reads connection info from DATABASE_URL.
-const dbConfig =
-  process.env.DB_DIALECT === 'postgres'
-    ? { dialect: 'postgres', url: process.env.DATABASE_URL }
-    : { dialect: 'sqlite', storage: databasePath };
+// DB_DIALECT: 'sqlite' (default) or 'postgres'.
+// Postgres connection info: prefer discrete DB_HOST/DB_PORT/DB_NAME/DB_USER/DB_PASSWORD
+// over DATABASE_URL — a password with special characters (%, #, @, /, etc.) is
+// structurally ambiguous once embedded in a URL and requires percent-encoding to
+// parse correctly; passing the raw fields to Sequelize sidesteps URL parsing
+// entirely. DATABASE_URL remains supported as a fallback for passwords that
+// don't need encoding.
+const postgresConfig = process.env.DB_HOST
+  ? {
+      dialect: 'postgres',
+      host: process.env.DB_HOST,
+      port: process.env.DB_PORT ? parseInt(process.env.DB_PORT, 10) : 5432,
+      database: process.env.DB_NAME,
+      username: process.env.DB_USER,
+      password: process.env.DB_PASSWORD,
+    }
+  : { dialect: 'postgres', url: process.env.DATABASE_URL };
+
+const dbConfig = process.env.DB_DIALECT === 'postgres' ? postgresConfig : { dialect: 'sqlite', storage: databasePath };
 
 export default {
   development: dbConfig,

--- a/backend/config/config.js
+++ b/backend/config/config.js
@@ -10,17 +10,14 @@ export const API_PATH = process.env.API_PATH || '/api';
 
 const databasePath = process.env.DATABASE_PATH ?? path.resolve(process.cwd(), 'database/database.sqlite');
 
+// DB_DIALECT: 'sqlite' (default) or 'postgres'. Postgres reads connection info from DATABASE_URL.
+const dbConfig =
+  process.env.DB_DIALECT === 'postgres'
+    ? { dialect: 'postgres', url: process.env.DATABASE_URL }
+    : { dialect: 'sqlite', storage: databasePath };
+
 export default {
-  development: {
-    dialect: 'sqlite',
-    storage: databasePath,
-  },
-  test: {
-    dialect: 'sqlite',
-    storage: databasePath,
-  },
-  production: {
-    dialect: 'sqlite',
-    storage: databasePath,
-  },
+  development: dbConfig,
+  test: dbConfig,
+  production: dbConfig,
 };

--- a/backend/config/config.js
+++ b/backend/config/config.js
@@ -10,25 +10,11 @@ export const API_PATH = process.env.API_PATH || '/api';
 
 const databasePath = process.env.DATABASE_PATH ?? path.resolve(process.cwd(), 'database/database.sqlite');
 
-// DB_DIALECT: 'sqlite' (default) or 'postgres'.
-// Postgres connection info: prefer discrete DB_HOST/DB_PORT/DB_NAME/DB_USER/DB_PASSWORD
-// over DATABASE_URL — a password with special characters (%, #, @, /, etc.) is
-// structurally ambiguous once embedded in a URL and requires percent-encoding to
-// parse correctly; passing the raw fields to Sequelize sidesteps URL parsing
-// entirely. DATABASE_URL remains supported as a fallback for passwords that
-// don't need encoding.
-const postgresConfig = process.env.DB_HOST
-  ? {
-      dialect: 'postgres',
-      host: process.env.DB_HOST,
-      port: process.env.DB_PORT ? parseInt(process.env.DB_PORT, 10) : 5432,
-      database: process.env.DB_NAME,
-      username: process.env.DB_USER,
-      password: process.env.DB_PASSWORD,
-    }
-  : { dialect: 'postgres', url: process.env.DATABASE_URL };
-
-const dbConfig = process.env.DB_DIALECT === 'postgres' ? postgresConfig : { dialect: 'sqlite', storage: databasePath };
+// DB_DIALECT: 'sqlite' (default) or 'postgres'. Postgres reads connection info from DATABASE_URL.
+const dbConfig =
+  process.env.DB_DIALECT === 'postgres'
+    ? { dialect: 'postgres', url: process.env.DATABASE_URL }
+    : { dialect: 'sqlite', storage: databasePath };
 
 export default {
   development: dbConfig,

--- a/backend/migrations/20250712000000-rename-path-to-filename-in-attachments.js
+++ b/backend/migrations/20250712000000-rename-path-to-filename-in-attachments.js
@@ -1,9 +1,9 @@
 export async function up(queryInterface) {
-  // Rename column 'path' to 'filename' in 'Attachments' table
-  await queryInterface.renameColumn('Attachments', 'path', 'filename');
+  // Rename column 'path' to 'filename' in 'attachments' table
+  await queryInterface.renameColumn('attachments', 'path', 'filename');
 }
 
 export async function down(queryInterface) {
   // Revert column name from 'filename' back to 'path'
-  await queryInterface.renameColumn('Attachments', 'filename', 'path');
+  await queryInterface.renameColumn('attachments', 'filename', 'path');
 }

--- a/backend/migrations/20260714120000-widen-case-and-step-text-columns.js
+++ b/backend/migrations/20260714120000-widen-case-and-step-text-columns.js
@@ -1,0 +1,50 @@
+// cases.description/preConditions/expectedResults and steps.step/result hold
+// free-form prose (test descriptions, step instructions, expected results)
+// that regularly exceeds VARCHAR(255) — SQLite never enforces the length
+// limit, so this went unnoticed there; Postgres does, and rejects real
+// import data with "value too long for type character varying(255)".
+export async function up(queryInterface, Sequelize) {
+  await queryInterface.changeColumn('cases', 'description', {
+    type: Sequelize.TEXT,
+    allowNull: true,
+  });
+  await queryInterface.changeColumn('cases', 'preConditions', {
+    type: Sequelize.TEXT,
+    allowNull: true,
+  });
+  await queryInterface.changeColumn('cases', 'expectedResults', {
+    type: Sequelize.TEXT,
+    allowNull: true,
+  });
+  await queryInterface.changeColumn('steps', 'step', {
+    type: Sequelize.TEXT,
+    allowNull: false,
+  });
+  await queryInterface.changeColumn('steps', 'result', {
+    type: Sequelize.TEXT,
+    allowNull: false,
+  });
+}
+
+export async function down(queryInterface, Sequelize) {
+  await queryInterface.changeColumn('cases', 'description', {
+    type: Sequelize.STRING,
+    allowNull: true,
+  });
+  await queryInterface.changeColumn('cases', 'preConditions', {
+    type: Sequelize.STRING,
+    allowNull: true,
+  });
+  await queryInterface.changeColumn('cases', 'expectedResults', {
+    type: Sequelize.STRING,
+    allowNull: true,
+  });
+  await queryInterface.changeColumn('steps', 'step', {
+    type: Sequelize.STRING,
+    allowNull: false,
+  });
+  await queryInterface.changeColumn('steps', 'result', {
+    type: Sequelize.STRING,
+    allowNull: false,
+  });
+}

--- a/backend/models/attachments.js
+++ b/backend/models/attachments.js
@@ -12,7 +12,7 @@ function defineAttachment(sequelize, DataTypes) {
       type: DataTypes.STRING,
       allowNull: false,
     },
-  });
+  }, { tableName: 'attachments' });
 
   Attachment.associate = (models) => {
     Attachment.belongsToMany(models.Case, {

--- a/backend/models/attachments.js
+++ b/backend/models/attachments.js
@@ -17,6 +17,8 @@ function defineAttachment(sequelize, DataTypes) {
   Attachment.associate = (models) => {
     Attachment.belongsToMany(models.Case, {
       through: 'caseAttachments',
+      foreignKey: 'attachmentId',
+      otherKey: 'caseId',
     });
   };
 

--- a/backend/models/caseAttachments.js
+++ b/backend/models/caseAttachments.js
@@ -8,7 +8,7 @@ function defineCaseAttachment(sequelize, DataTypes) {
       type: DataTypes.INTEGER,
       allowNull: false,
     },
-  });
+  }, { tableName: 'caseAttachments' });
 
   CaseAttachment.associate = (models) => {
     CaseAttachment.belongsTo(models.Case, {

--- a/backend/models/caseSteps.js
+++ b/backend/models/caseSteps.js
@@ -12,7 +12,7 @@ function defineCaseStep(sequelize, DataTypes) {
       type: DataTypes.INTEGER,
       allowNull: false,
     },
-  });
+  }, { tableName: 'caseSteps' });
 
   CaseStep.associate = (models) => {
     CaseStep.belongsTo(models.Case, {

--- a/backend/models/caseTags.js
+++ b/backend/models/caseTags.js
@@ -23,7 +23,7 @@ function definecaseTags(sequelize, DataTypes) {
       },
       onDelete: 'CASCADE',
     },
-  });
+  }, { tableName: 'caseTags' });
 
   caseTags.associate = (models) => {
     caseTags.belongsTo(models.Case, { foreignKey: 'caseId', onDelete: 'CASCADE' });

--- a/backend/models/cases.js
+++ b/backend/models/cases.js
@@ -45,7 +45,7 @@ function defineCase(sequelize, DataTypes) {
       },
       onDelete: 'CASCADE',
     },
-  });
+  }, { tableName: 'cases' });
 
   Case.associate = (models) => {
     Case.belongsTo(models.Folder, {

--- a/backend/models/cases.js
+++ b/backend/models/cases.js
@@ -54,6 +54,8 @@ function defineCase(sequelize, DataTypes) {
     });
     Case.belongsToMany(models.Step, {
       through: 'caseSteps',
+      foreignKey: 'caseId',
+      otherKey: 'stepId',
     });
     Case.belongsToMany(models.Tags, {
       through: 'caseTags',

--- a/backend/models/cases.js
+++ b/backend/models/cases.js
@@ -21,7 +21,7 @@ function defineCase(sequelize, DataTypes) {
       allowNull: false,
     },
     description: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
       allowNull: true,
     },
     template: {
@@ -29,11 +29,11 @@ function defineCase(sequelize, DataTypes) {
       allowNull: false,
     },
     preConditions: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
       allowNull: true,
     },
     expectedResults: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
       allowNull: true,
     },
     folderId: {

--- a/backend/models/comments.js
+++ b/backend/models/comments.js
@@ -16,7 +16,7 @@ function defineComment(sequelize, DataTypes) {
       type: DataTypes.TEXT,
       allowNull: false,
     },
-  });
+  }, { tableName: 'comments' });
 
   Comment.associate = (models) => {
     // Polymorphic associations

--- a/backend/models/folders.js
+++ b/backend/models/folders.js
@@ -26,7 +26,7 @@ function defineFolder(sequelize, DataTypes) {
       },
       onDelete: 'CASCADE',
     },
-  });
+  }, { tableName: 'folders' });
 
   Folder.associate = (models) => {
     Folder.belongsTo(models.Project, { foreignKey: 'projectId', onDelete: 'CASCADE' });

--- a/backend/models/members.js
+++ b/backend/models/members.js
@@ -12,7 +12,7 @@ function defineMember(sequelize, DataTypes) {
       type: DataTypes.INTEGER,
       allowNull: false,
     },
-  });
+  }, { tableName: 'members' });
 
   Member.associate = (models) => {
     Member.belongsTo(models.User, {

--- a/backend/models/projects.js
+++ b/backend/models/projects.js
@@ -21,7 +21,7 @@ function defineProject(sequelize, DataTypes) {
       },
       onDelete: 'CASCADE',
     },
-  });
+  }, { tableName: 'projects' });
 
   Project.associate = (models) => {
     Project.belongsTo(models.User, { foreignKey: 'userId', onDelete: 'CASCADE' });

--- a/backend/models/runCases.js
+++ b/backend/models/runCases.js
@@ -17,7 +17,7 @@ function defineRunCase(sequelize, DataTypes) {
       allowNull: true,
       defaultValue: null,
     },
-  });
+  }, { tableName: 'runCases' });
 
   RunCase.associate = (models) => {
     RunCase.belongsTo(models.Run, {

--- a/backend/models/runs.js
+++ b/backend/models/runs.js
@@ -25,7 +25,7 @@ function defineRun(sequelize, DataTypes) {
       },
       onDelete: 'CASCADE',
     },
-  });
+  }, { tableName: 'runs' });
 
   Run.associate = (models) => {
     Run.belongsTo(models.Project, { foreignKey: 'projectId', onDelete: 'CASCADE' });

--- a/backend/models/steps.js
+++ b/backend/models/steps.js
@@ -8,7 +8,7 @@ function defineStep(sequelize, DataTypes) {
       type: DataTypes.STRING,
       allowNull: false,
     },
-  });
+  }, { tableName: 'steps' });
 
   Step.associate = (models) => {
     Step.belongsToMany(models.Case, {

--- a/backend/models/steps.js
+++ b/backend/models/steps.js
@@ -13,6 +13,8 @@ function defineStep(sequelize, DataTypes) {
   Step.associate = (models) => {
     Step.belongsToMany(models.Case, {
       through: 'caseSteps',
+      foreignKey: 'stepId',
+      otherKey: 'caseId',
     });
   };
 

--- a/backend/models/steps.js
+++ b/backend/models/steps.js
@@ -1,11 +1,11 @@
 function defineStep(sequelize, DataTypes) {
   const Step = sequelize.define('Step', {
     step: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
       allowNull: false,
     },
     result: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
       allowNull: false,
     },
   }, { tableName: 'steps' });

--- a/backend/models/tags.js
+++ b/backend/models/tags.js
@@ -13,7 +13,7 @@ function defineTag(sequelize, DataTypes) {
       },
       onDelete: 'CASCADE',
     },
-  });
+  }, { tableName: 'tags' });
 
   Tags.associate = (models) => {
     Tags.belongsTo(models.Project, {

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -17,6 +17,8 @@
         "jsonwebtoken": "^9.0.2",
         "multer": "^1.4.5-lts.1",
         "papaparse": "^5.5.2",
+        "pg": "^8.22.0",
+        "pg-hstore": "^2.3.4",
         "sequelize": "^6.37.7",
         "sequelize-cli": "^6.6.3",
         "sqlite3": "^5.1.7",
@@ -1629,7 +1631,6 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.34.tgz",
       "integrity": "sha512-by3/Z0Qp+L9cAySEsSNNwZ6WWw8ywgGLPQGgbQDhNRSitqYgkgp4pErd23ZSCavbtUA2CN4jQtoB3T8nk4j3Rg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -2953,6 +2954,29 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/encoding": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
+      "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "iconv-lite": "^0.6.2"
+      }
+    },
+    "node_modules/encoding/node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/end-of-stream": {
       "version": "1.4.4",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
@@ -3200,7 +3224,6 @@
       "resolved": "https://registry.npmjs.org/express/-/express-4.21.2.tgz",
       "integrity": "sha512-28HqgMZAmih1Czt9ny7qr6ek2qddF4FclbMzwhCREB6OFfH+rXAnuNCwo1/wFvrtbgsQDb4kSbX9de9lFbrXnA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "accepts": "~1.3.8",
         "array-flatten": "1.1.1",
@@ -5841,11 +5864,106 @@
       "integrity": "sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==",
       "license": "MIT"
     },
+    "node_modules/pg": {
+      "version": "8.22.0",
+      "resolved": "https://registry.npmjs.org/pg/-/pg-8.22.0.tgz",
+      "integrity": "sha512-8wih1vVIBMxoUM2oB4soJsD9tDnDpLv4OXBJ+EJzFsvycD+lfyIreC2gGHq78f8jbLLt+bvlPTFdFZfJkOuzAA==",
+      "license": "MIT",
+      "dependencies": {
+        "pg-connection-string": "^2.14.0",
+        "pg-pool": "^3.14.0",
+        "pg-protocol": "^1.15.0",
+        "pg-types": "2.2.0",
+        "pgpass": "1.0.5"
+      },
+      "engines": {
+        "node": ">= 16.0.0"
+      },
+      "optionalDependencies": {
+        "pg-cloudflare": "^1.4.0"
+      },
+      "peerDependencies": {
+        "pg-native": ">=3.0.1"
+      },
+      "peerDependenciesMeta": {
+        "pg-native": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/pg-cloudflare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/pg-cloudflare/-/pg-cloudflare-1.4.0.tgz",
+      "integrity": "sha512-Vo7z/6rrQYxpNRylp4Tlob2elzbh+N/MOQbxFVWCxS7oEx6jF53GTJFxK2WWpKuBRkmiin4Mt+xofFDjx09R0A==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/pg-connection-string": {
-      "version": "2.9.1",
-      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.9.1.tgz",
-      "integrity": "sha512-nkc6NpDcvPVpZXxrreI/FOtX3XemeLl8E0qFr6F2Lrm/I8WOnaWNhIPK2Z7OHpw7gh5XJThi6j6ppgNoaT1w4w==",
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.14.0.tgz",
+      "integrity": "sha512-XwWDGcLRGCXAR8F/AM5bG7Q+A3Wm2s6QeEjlOKZLlH3UYcguiqCWKyWXVag5TLTIjR7oOJUY8kcADaZgWPyLeg==",
       "license": "MIT"
+    },
+    "node_modules/pg-hstore": {
+      "version": "2.3.4",
+      "resolved": "https://registry.npmjs.org/pg-hstore/-/pg-hstore-2.3.4.tgz",
+      "integrity": "sha512-N3SGs/Rf+xA1M2/n0JBiXFDVMzdekwLZLAO0g7mpDY9ouX+fDI7jS6kTq3JujmYbtNSJ53TJ0q4G98KVZSM4EA==",
+      "license": "MIT",
+      "dependencies": {
+        "underscore": "^1.13.1"
+      },
+      "engines": {
+        "node": ">= 0.8.x"
+      }
+    },
+    "node_modules/pg-int8": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
+      "integrity": "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/pg-pool": {
+      "version": "3.14.0",
+      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.14.0.tgz",
+      "integrity": "sha512-gKtPkFdQPU3DksooVLi9LsjZxrsBUZIpa+7aVx+LV5pNh0KzP4Zleud2po+ConrxbuXGBJ6Hfer6hdgpIBpBaw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "pg": ">=8.0"
+      }
+    },
+    "node_modules/pg-protocol": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.15.0.tgz",
+      "integrity": "sha512-cq9sECI5s0+uPUXjbz8ioyPJni6RzsRib0US67i5IoTZKw8fNeYlVE7u8F4dG7vEJJtc5wdD1K189lCCUwqWTQ==",
+      "license": "MIT"
+    },
+    "node_modules/pg-types": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-2.2.0.tgz",
+      "integrity": "sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==",
+      "license": "MIT",
+      "dependencies": {
+        "pg-int8": "1.0.1",
+        "postgres-array": "~2.0.0",
+        "postgres-bytea": "~1.0.0",
+        "postgres-date": "~1.0.4",
+        "postgres-interval": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/pgpass": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/pgpass/-/pgpass-1.0.5.tgz",
+      "integrity": "sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==",
+      "license": "MIT",
+      "dependencies": {
+        "split2": "^4.1.0"
+      }
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -5873,6 +5991,45 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/postgres-array": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-2.0.0.tgz",
+      "integrity": "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/postgres-bytea": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-1.0.1.tgz",
+      "integrity": "sha512-5+5HqXnsZPE65IJZSMkZtURARZelel2oXUEO8rH83VS/hxH5vv1uHquPg5wZs8yMAfdv971IU+kcPUczi7NVBQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-date": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-1.0.7.tgz",
+      "integrity": "sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-interval": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-1.2.0.tgz",
+      "integrity": "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "xtend": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/prebuild-install": {
@@ -6825,6 +6982,15 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/split2": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
+      "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 10.x"
+      }
+    },
     "node_modules/sprintf-js": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
@@ -7401,7 +7567,6 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -7458,6 +7623,12 @@
       "resolved": "https://registry.npmjs.org/undefsafe/-/undefsafe-2.0.5.tgz",
       "integrity": "sha512-WxONCrssBM8TSPRqN5EmsjVrsv4A8X12J4ArBiiayv3DyyG3ZlIg6yysuuSYdZsVz3TKcTg2fd//Ujd4CHV1iA==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/underscore": {
+      "version": "1.13.8",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.8.tgz",
+      "integrity": "sha512-DXtD3ZtEQzc7M8m4cXotyHR+FAS18C64asBYY5vqZexfYryNNnDc02W4hKg3rdQuqOYas1jkseX0+nZXjTXnvQ==",
       "license": "MIT"
     },
     "node_modules/undici-types": {
@@ -8944,7 +9115,6 @@
       "version": "20.19.34",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.34.tgz",
       "integrity": "sha512-by3/Z0Qp+L9cAySEsSNNwZ6WWw8ywgGLPQGgbQDhNRSitqYgkgp4pErd23ZSCavbtUA2CN4jQtoB3T8nk4j3Rg==",
-      "peer": true,
       "requires": {
         "undici-types": "~6.21.0"
       }
@@ -9891,6 +10061,26 @@
       "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
       "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg=="
     },
+    "encoding": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
+      "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
+      "optional": true,
+      "requires": {
+        "iconv-lite": "^0.6.2"
+      },
+      "dependencies": {
+        "iconv-lite": {
+          "version": "0.6.3",
+          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+          "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+          "optional": true,
+          "requires": {
+            "safer-buffer": ">= 2.1.2 < 3.0.0"
+          }
+        }
+      }
+    },
     "end-of-stream": {
       "version": "1.4.4",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
@@ -10079,7 +10269,6 @@
       "version": "4.21.2",
       "resolved": "https://registry.npmjs.org/express/-/express-4.21.2.tgz",
       "integrity": "sha512-28HqgMZAmih1Czt9ny7qr6ek2qddF4FclbMzwhCREB6OFfH+rXAnuNCwo1/wFvrtbgsQDb4kSbX9de9lFbrXnA==",
-      "peer": true,
       "requires": {
         "accepts": "~1.3.8",
         "array-flatten": "1.1.1",
@@ -11828,10 +12017,73 @@
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.12.tgz",
       "integrity": "sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ=="
     },
+    "pg": {
+      "version": "8.22.0",
+      "resolved": "https://registry.npmjs.org/pg/-/pg-8.22.0.tgz",
+      "integrity": "sha512-8wih1vVIBMxoUM2oB4soJsD9tDnDpLv4OXBJ+EJzFsvycD+lfyIreC2gGHq78f8jbLLt+bvlPTFdFZfJkOuzAA==",
+      "requires": {
+        "pg-cloudflare": "^1.4.0",
+        "pg-connection-string": "^2.14.0",
+        "pg-pool": "^3.14.0",
+        "pg-protocol": "^1.15.0",
+        "pg-types": "2.2.0",
+        "pgpass": "1.0.5"
+      }
+    },
+    "pg-cloudflare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/pg-cloudflare/-/pg-cloudflare-1.4.0.tgz",
+      "integrity": "sha512-Vo7z/6rrQYxpNRylp4Tlob2elzbh+N/MOQbxFVWCxS7oEx6jF53GTJFxK2WWpKuBRkmiin4Mt+xofFDjx09R0A==",
+      "optional": true
+    },
     "pg-connection-string": {
-      "version": "2.9.1",
-      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.9.1.tgz",
-      "integrity": "sha512-nkc6NpDcvPVpZXxrreI/FOtX3XemeLl8E0qFr6F2Lrm/I8WOnaWNhIPK2Z7OHpw7gh5XJThi6j6ppgNoaT1w4w=="
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.14.0.tgz",
+      "integrity": "sha512-XwWDGcLRGCXAR8F/AM5bG7Q+A3Wm2s6QeEjlOKZLlH3UYcguiqCWKyWXVag5TLTIjR7oOJUY8kcADaZgWPyLeg=="
+    },
+    "pg-hstore": {
+      "version": "2.3.4",
+      "resolved": "https://registry.npmjs.org/pg-hstore/-/pg-hstore-2.3.4.tgz",
+      "integrity": "sha512-N3SGs/Rf+xA1M2/n0JBiXFDVMzdekwLZLAO0g7mpDY9ouX+fDI7jS6kTq3JujmYbtNSJ53TJ0q4G98KVZSM4EA==",
+      "requires": {
+        "underscore": "^1.13.1"
+      }
+    },
+    "pg-int8": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
+      "integrity": "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw=="
+    },
+    "pg-pool": {
+      "version": "3.14.0",
+      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.14.0.tgz",
+      "integrity": "sha512-gKtPkFdQPU3DksooVLi9LsjZxrsBUZIpa+7aVx+LV5pNh0KzP4Zleud2po+ConrxbuXGBJ6Hfer6hdgpIBpBaw==",
+      "requires": {}
+    },
+    "pg-protocol": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.15.0.tgz",
+      "integrity": "sha512-cq9sECI5s0+uPUXjbz8ioyPJni6RzsRib0US67i5IoTZKw8fNeYlVE7u8F4dG7vEJJtc5wdD1K189lCCUwqWTQ=="
+    },
+    "pg-types": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-2.2.0.tgz",
+      "integrity": "sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==",
+      "requires": {
+        "pg-int8": "1.0.1",
+        "postgres-array": "~2.0.0",
+        "postgres-bytea": "~1.0.0",
+        "postgres-date": "~1.0.4",
+        "postgres-interval": "^1.1.0"
+      }
+    },
+    "pgpass": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/pgpass/-/pgpass-1.0.5.tgz",
+      "integrity": "sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==",
+      "requires": {
+        "split2": "^4.1.0"
+      }
     },
     "picocolors": {
       "version": "1.1.1",
@@ -11848,6 +12100,29 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
       "integrity": "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg=="
+    },
+    "postgres-array": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-2.0.0.tgz",
+      "integrity": "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA=="
+    },
+    "postgres-bytea": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-1.0.1.tgz",
+      "integrity": "sha512-5+5HqXnsZPE65IJZSMkZtURARZelel2oXUEO8rH83VS/hxH5vv1uHquPg5wZs8yMAfdv971IU+kcPUczi7NVBQ=="
+    },
+    "postgres-date": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-1.0.7.tgz",
+      "integrity": "sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q=="
+    },
+    "postgres-interval": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-1.2.0.tgz",
+      "integrity": "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==",
+      "requires": {
+        "xtend": "^4.0.0"
+      }
     },
     "prebuild-install": {
       "version": "7.1.1",
@@ -12458,6 +12733,11 @@
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
     },
+    "split2": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
+      "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg=="
+    },
     "sprintf-js": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
@@ -12849,8 +13129,7 @@
     "typescript": {
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-      "peer": true
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="
     },
     "uglify-js": {
       "version": "3.19.3",
@@ -12882,6 +13161,11 @@
       "resolved": "https://registry.npmjs.org/undefsafe/-/undefsafe-2.0.5.tgz",
       "integrity": "sha512-WxONCrssBM8TSPRqN5EmsjVrsv4A8X12J4ArBiiayv3DyyG3ZlIg6yysuuSYdZsVz3TKcTg2fd//Ujd4CHV1iA==",
       "dev": true
+    },
+    "underscore": {
+      "version": "1.13.8",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.8.tgz",
+      "integrity": "sha512-DXtD3ZtEQzc7M8m4cXotyHR+FAS18C64asBYY5vqZexfYryNNnDc02W4hKg3rdQuqOYas1jkseX0+nZXjTXnvQ=="
     },
     "undici-types": {
       "version": "6.21.0",

--- a/backend/package.json
+++ b/backend/package.json
@@ -22,6 +22,8 @@
     "jsonwebtoken": "^9.0.2",
     "multer": "^1.4.5-lts.1",
     "papaparse": "^5.5.2",
+    "pg": "^8.22.0",
+    "pg-hstore": "^2.3.4",
     "sequelize": "^6.37.7",
     "sequelize-cli": "^6.6.3",
     "sqlite3": "^5.1.7",

--- a/backend/routes/cases/clone.js
+++ b/backend/routes/cases/clone.js
@@ -13,8 +13,8 @@ export default function (sequelize) {
   const Case = defineCase(sequelize, DataTypes);
   const Step = defineStep(sequelize, DataTypes);
   const CaseStep = defineCaseStep(sequelize, DataTypes);
-  Case.belongsToMany(Step, { through: 'caseSteps' });
-  Step.belongsToMany(Case, { through: 'caseSteps' });
+  Case.belongsToMany(Step, { through: 'caseSteps', foreignKey: 'caseId', otherKey: 'stepId' });
+  Step.belongsToMany(Case, { through: 'caseSteps', foreignKey: 'stepId', otherKey: 'caseId' });
 
   // TODO:  Implement a safer middleware to check permissions based on the actual caseId (in this case, multiples case ids)
   router.post('/clone', verifySignedIn, verifyProjectDeveloperFromProjectId, async (req, res) => {

--- a/backend/routes/cases/download.js
+++ b/backend/routes/cases/download.js
@@ -15,8 +15,8 @@ export default function (sequelize) {
   const Step = defineStep(sequelize, DataTypes);
   const Folder = defineFolder(sequelize, DataTypes);
   Case.belongsTo(Folder);
-  Case.belongsToMany(Step, { through: 'caseSteps' });
-  Step.belongsToMany(Case, { through: 'caseSteps' });
+  Case.belongsToMany(Step, { through: 'caseSteps', foreignKey: 'caseId', otherKey: 'stepId' });
+  Step.belongsToMany(Case, { through: 'caseSteps', foreignKey: 'stepId', otherKey: 'caseId' });
   const { verifySignedIn } = authMiddleware(sequelize);
   const { verifyProjectVisibleFromFolderId } = visibilityMiddleware(sequelize);
 

--- a/backend/routes/cases/indexByProjectId.js
+++ b/backend/routes/cases/indexByProjectId.js
@@ -130,9 +130,9 @@ export default function (sequelize) {
                 'assigneeUserId',
                 [
                   sequelize.literal(
-                    '(SELECT COUNT(*) FROM `comments` WHERE `comments`.`commentableType` = ' +
+                    '(SELECT COUNT(*) FROM "comments" WHERE "comments"."commentableType" = ' +
                       sequelize.escape('RunCase') +
-                      ' AND `comments`.`commentableId` = `RunCases`.`id`)'
+                      ' AND "comments"."commentableId" = "RunCases"."id")'
                   ),
                   'commentCount',
                 ],

--- a/backend/routes/cases/show.js
+++ b/backend/routes/cases/show.js
@@ -14,10 +14,10 @@ export default function (sequelize) {
   const Step = defineStep(sequelize, DataTypes);
   const Tags = defineTag(sequelize, DataTypes);
   const Attachment = defineAttachment(sequelize, DataTypes);
-  Case.belongsToMany(Step, { through: 'caseSteps' });
-  Step.belongsToMany(Case, { through: 'caseSteps' });
-  Case.belongsToMany(Attachment, { through: 'caseAttachments' });
-  Attachment.belongsToMany(Case, { through: 'caseAttachments' });
+  Case.belongsToMany(Step, { through: 'caseSteps', foreignKey: 'caseId', otherKey: 'stepId' });
+  Step.belongsToMany(Case, { through: 'caseSteps', foreignKey: 'stepId', otherKey: 'caseId' });
+  Case.belongsToMany(Attachment, { through: 'caseAttachments', foreignKey: 'caseId', otherKey: 'attachmentId' });
+  Attachment.belongsToMany(Case, { through: 'caseAttachments', foreignKey: 'attachmentId', otherKey: 'caseId' });
   Case.belongsToMany(Tags, { through: 'caseTags', foreignKey: 'caseId', otherKey: 'tagId' });
   Tags.belongsToMany(Case, { through: 'caseTags', foreignKey: 'tagId', otherKey: 'caseId' });
   const RunCase = defineRunCase(sequelize, DataTypes);

--- a/backend/routes/folders/clone.js
+++ b/backend/routes/folders/clone.js
@@ -17,8 +17,8 @@ export default function (sequelize) {
   const Step = defineStep(sequelize, DataTypes);
   const CaseStep = defineCaseStep(sequelize, DataTypes);
   Case.belongsTo(Folder);
-  Case.belongsToMany(Step, { through: 'caseSteps' });
-  Step.belongsToMany(Case, { through: 'caseSteps' });
+  Case.belongsToMany(Step, { through: 'caseSteps', foreignKey: 'caseId', otherKey: 'stepId' });
+  Step.belongsToMany(Case, { through: 'caseSteps', foreignKey: 'stepId', otherKey: 'caseId' });
 
   async function _cloneFolderRecursive(sourceFolder, targetParent, transaction) {
     const folderToCreate = {

--- a/backend/server.ts
+++ b/backend/server.ts
@@ -43,26 +43,10 @@ app.use('/api-docs', swaggerUi.serve, swaggerUi.setup(swaggerDocument));
 const backendDir = path.basename(__dirname) === 'dist' ? path.resolve(__dirname, '..') : __dirname;
 const databasePath = process.env.DATABASE_PATH ?? path.resolve(backendDir, 'database/database.sqlite');
 
-// DB_DIALECT: 'sqlite' (default) or 'postgres'.
-// Postgres connection info: prefer discrete DB_HOST/DB_PORT/DB_NAME/DB_USER/DB_PASSWORD
-// over DATABASE_URL — a password with special characters (%, #, @, /, etc.) is
-// structurally ambiguous once embedded in a URL and requires percent-encoding to
-// parse correctly; passing the raw fields to Sequelize sidesteps URL parsing
-// entirely. DATABASE_URL remains supported as a fallback for passwords that
-// don't need encoding.
+// DB_DIALECT: 'sqlite' (default) or 'postgres'. Postgres reads connection info from DATABASE_URL.
 export const sequelize =
   process.env.DB_DIALECT === 'postgres'
-    ? process.env.DB_HOST
-      ? new Sequelize({
-          dialect: 'postgres',
-          host: process.env.DB_HOST,
-          port: process.env.DB_PORT ? parseInt(process.env.DB_PORT, 10) : 5432,
-          database: process.env.DB_NAME,
-          username: process.env.DB_USER,
-          password: process.env.DB_PASSWORD,
-          logging: false,
-        })
-      : new Sequelize(process.env.DATABASE_URL as string, { dialect: 'postgres', logging: false })
+    ? new Sequelize(process.env.DATABASE_URL as string, { dialect: 'postgres', logging: false })
     : new Sequelize({ dialect: 'sqlite', storage: databasePath, logging: false });
 
 // Register TSOA-generated routes (TypeScript controllers)

--- a/backend/server.ts
+++ b/backend/server.ts
@@ -42,11 +42,12 @@ app.use('/api-docs', swaggerUi.serve, swaggerUi.setup(swaggerDocument));
 // __dirname is backend/ in dev (ts-node) and backend/dist/ in production (compiled)
 const backendDir = path.basename(__dirname) === 'dist' ? path.resolve(__dirname, '..') : __dirname;
 const databasePath = process.env.DATABASE_PATH ?? path.resolve(backendDir, 'database/database.sqlite');
-export const sequelize = new Sequelize({
-  dialect: 'sqlite',
-  storage: databasePath,
-  logging: false,
-});
+
+// DB_DIALECT: 'sqlite' (default) or 'postgres'. Postgres reads connection info from DATABASE_URL.
+export const sequelize =
+  process.env.DB_DIALECT === 'postgres'
+    ? new Sequelize(process.env.DATABASE_URL as string, { dialect: 'postgres', logging: false })
+    : new Sequelize({ dialect: 'sqlite', storage: databasePath, logging: false });
 
 // Register TSOA-generated routes (TypeScript controllers)
 RegisterRoutes(app);

--- a/backend/server.ts
+++ b/backend/server.ts
@@ -43,10 +43,26 @@ app.use('/api-docs', swaggerUi.serve, swaggerUi.setup(swaggerDocument));
 const backendDir = path.basename(__dirname) === 'dist' ? path.resolve(__dirname, '..') : __dirname;
 const databasePath = process.env.DATABASE_PATH ?? path.resolve(backendDir, 'database/database.sqlite');
 
-// DB_DIALECT: 'sqlite' (default) or 'postgres'. Postgres reads connection info from DATABASE_URL.
+// DB_DIALECT: 'sqlite' (default) or 'postgres'.
+// Postgres connection info: prefer discrete DB_HOST/DB_PORT/DB_NAME/DB_USER/DB_PASSWORD
+// over DATABASE_URL — a password with special characters (%, #, @, /, etc.) is
+// structurally ambiguous once embedded in a URL and requires percent-encoding to
+// parse correctly; passing the raw fields to Sequelize sidesteps URL parsing
+// entirely. DATABASE_URL remains supported as a fallback for passwords that
+// don't need encoding.
 export const sequelize =
   process.env.DB_DIALECT === 'postgres'
-    ? new Sequelize(process.env.DATABASE_URL as string, { dialect: 'postgres', logging: false })
+    ? process.env.DB_HOST
+      ? new Sequelize({
+          dialect: 'postgres',
+          host: process.env.DB_HOST,
+          port: process.env.DB_PORT ? parseInt(process.env.DB_PORT, 10) : 5432,
+          database: process.env.DB_NAME,
+          username: process.env.DB_USER,
+          password: process.env.DB_PASSWORD,
+          logging: false,
+        })
+      : new Sequelize(process.env.DATABASE_URL as string, { dialect: 'postgres', logging: false })
     : new Sequelize({ dialect: 'sqlite', storage: databasePath, logging: false });
 
 // Register TSOA-generated routes (TypeScript controllers)

--- a/docs/docs/getstarted/environment.md
+++ b/docs/docs/getstarted/environment.md
@@ -12,6 +12,17 @@ It is strongly recommended to change `SECRET_KEY` from the default value in prod
 
 :::
 
+## Database backend
+
+By default UnitTCMS uses SQLite, configured via `DATABASE_PATH`. To use PostgreSQL instead, set `DB_DIALECT=postgres` and `DATABASE_URL` to a Postgres connection string:
+
+```
+DB_DIALECT=postgres
+DATABASE_URL=postgres://user:password@host:5432/database
+```
+
+`DATABASE_URL` is ignored when `DB_DIALECT` is unset or `sqlite`, and `DATABASE_PATH` is ignored when `DB_DIALECT=postgres`.
+
 ## Docker
 
 If you are self-hosting UnitTCMS with Docker, you can customize the environment using the `environment` section in `docker-compose.yaml`.
@@ -30,6 +41,8 @@ services:
       - IS_DEMO=false # set to true to seed the database
       - API_PATH=/api
       - DATABASE_PATH=/app/backend/database/database.sqlite
+      # - DB_DIALECT=postgres
+      # - DATABASE_URL=postgres://user:password@host:5432/database
     // highlight-end
     volumes:
       - db-data:/app/backend/database

--- a/docs/docs/getstarted/environment.md
+++ b/docs/docs/getstarted/environment.md
@@ -14,14 +14,25 @@ It is strongly recommended to change `SECRET_KEY` from the default value in prod
 
 ## Database backend
 
-By default UnitTCMS uses SQLite, configured via `DATABASE_PATH`. To use PostgreSQL instead, set `DB_DIALECT=postgres` and `DATABASE_URL` to a Postgres connection string:
+By default UnitTCMS uses SQLite, configured via `DATABASE_PATH`. To use PostgreSQL instead, set `DB_DIALECT=postgres` plus connection info, via either discrete fields (recommended) or a single URL:
+
+```
+DB_DIALECT=postgres
+DB_HOST=host
+DB_PORT=5432
+DB_NAME=database
+DB_USER=user
+DB_PASSWORD=password
+```
 
 ```
 DB_DIALECT=postgres
 DATABASE_URL=postgres://user:password@host:5432/database
 ```
 
-`DATABASE_URL` is ignored when `DB_DIALECT` is unset or `sqlite`, and `DATABASE_PATH` is ignored when `DB_DIALECT=postgres`.
+Prefer the discrete `DB_HOST`/`DB_PORT`/`DB_NAME`/`DB_USER`/`DB_PASSWORD` fields when the password contains special characters (`%`, `#`, `@`, `/`, etc.) — those characters are structurally ambiguous once embedded in a URL and require percent-encoding to parse correctly; the discrete fields are passed straight through to the database driver with no URL parsing involved. `DATABASE_URL` is only used when `DB_HOST` is unset.
+
+Both are ignored when `DB_DIALECT` is unset or `sqlite`, and `DATABASE_PATH` is ignored when `DB_DIALECT=postgres`.
 
 ## Docker
 

--- a/docs/docs/getstarted/environment.md
+++ b/docs/docs/getstarted/environment.md
@@ -14,25 +14,14 @@ It is strongly recommended to change `SECRET_KEY` from the default value in prod
 
 ## Database backend
 
-By default UnitTCMS uses SQLite, configured via `DATABASE_PATH`. To use PostgreSQL instead, set `DB_DIALECT=postgres` plus connection info, via either discrete fields (recommended) or a single URL:
-
-```
-DB_DIALECT=postgres
-DB_HOST=host
-DB_PORT=5432
-DB_NAME=database
-DB_USER=user
-DB_PASSWORD=password
-```
+By default UnitTCMS uses SQLite, configured via `DATABASE_PATH`. To use PostgreSQL instead, set `DB_DIALECT=postgres` and `DATABASE_URL` to a Postgres connection string:
 
 ```
 DB_DIALECT=postgres
 DATABASE_URL=postgres://user:password@host:5432/database
 ```
 
-Prefer the discrete `DB_HOST`/`DB_PORT`/`DB_NAME`/`DB_USER`/`DB_PASSWORD` fields when the password contains special characters (`%`, `#`, `@`, `/`, etc.) — those characters are structurally ambiguous once embedded in a URL and require percent-encoding to parse correctly; the discrete fields are passed straight through to the database driver with no URL parsing involved. `DATABASE_URL` is only used when `DB_HOST` is unset.
-
-Both are ignored when `DB_DIALECT` is unset or `sqlite`, and `DATABASE_PATH` is ignored when `DB_DIALECT=postgres`.
+`DATABASE_URL` is ignored when `DB_DIALECT` is unset or `sqlite`, and `DATABASE_PATH` is ignored when `DB_DIALECT=postgres`.
 
 ## Docker
 


### PR DESCRIPTION
## Summary
- Add `DB_DIALECT` env var (`sqlite` default, `postgres` via `DATABASE_URL`) in `backend/config/config.js` and `backend/server.ts`
- Add `pg`/`pg-hstore` dependencies
- Fix Postgres-incompatible raw SQL: backtick-quoted identifiers in `indexByProjectId.js` comment-count subquery
- Fix a migration that renamed a column on `'Attachments'` (capital A) instead of the actual `attachments` table — silently worked on SQLite (case-insensitive matching), broke on Postgres
- Add explicit `tableName` to 13 models that had none, so Sequelize's default pluralized/capitalized table name (e.g. `Project` -> `"Projects"`) matches the actual lowercase table created by migrations

## Test plan
- [x] Ran all 19 existing migrations from scratch against a real PostgreSQL 16 (Docker) instance — clean
- [x] Seeded demo data against Postgres
- [x] Exercised API directly (signin, projects, folders, runs, cases, the fixed comment-count subquery) against Postgres — all correct
- [x] Signed in through the browser (Playwright) and confirmed project list, folders, cases, and progress dashboards render real Postgres-backed data
- [x] No change to default behavior: `DB_DIALECT` unset still uses SQLite exactly as before